### PR TITLE
Add portfolio routes and page shells

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "react-router-dom": "latest"
   },
   "devDependencies": {
     "@types/react": "latest",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,50 +1,52 @@
+import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom';
 import backgroundImage from './assets/images/background.png';
-
-const legacyPages = [
-  { href: 'docs/legacy/about.html', label: 'За мен / About' },
-  { href: 'docs/legacy/contacts.html', label: 'Контакти / Contacts' },
-  { href: 'docs/legacy/links.html', label: 'Линкове / Links' },
-];
+import { navigationItems } from './data/navigation';
+import AboutPage from './pages/AboutPage';
+import BlogPage from './pages/BlogPage';
+import ContactPage from './pages/ContactPage';
+import HomePage from './pages/HomePage';
+import LinksPage from './pages/LinksPage';
+import NotFoundPage from './pages/NotFoundPage';
+import ProjectDetailPage from './pages/ProjectDetailPage';
+import ProjectsPage from './pages/ProjectsPage';
+import SkillsPage from './pages/SkillsPage';
+import { routes } from './utils/routes';
 
 function App() {
   return (
-    <main
-      className="app-shell"
-      style={{
-        backgroundImage: `linear-gradient(135deg, rgba(15, 23, 42, 0.88), rgba(30, 64, 175, 0.54)), url(${backgroundImage})`,
-      }}
-    >
-      <nav className="top-nav" aria-label="Legacy site reference pages">
-        {legacyPages.map((page) => (
-          <a key={page.href} href={page.href}>
-            {page.label}
-          </a>
-        ))}
-      </nav>
+    <BrowserRouter>
+      <main
+        className="app-shell"
+        style={{
+          backgroundImage: `linear-gradient(135deg, rgba(15, 23, 42, 0.88), rgba(30, 64, 175, 0.54)), url(${backgroundImage})`,
+        }}
+      >
+        <nav className="top-nav" aria-label="Primary portfolio navigation">
+          {navigationItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.end}
+              className={({ isActive }) => (isActive ? 'active' : undefined)}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
 
-      <section className="hero-card" aria-labelledby="site-title">
-        <p className="eyebrow">Vite + React + TypeScript foundation</p>
-        <h1 id="site-title">Алгоритъмът на деня | Algorithm of the Day</h1>
-        <p className="intro">
-          Това е новата основа на обучителната уеб страница и лична визитка на
-          Aleksandar Kitipov. Статичната HTML версия е архивирана като справка, докато
-          модерното React приложение се развива стъпка по стъпка.
-        </p>
-        <p className="intro">
-          This first React milestone preserves the original spirit of the site and
-          prepares it for future portfolio sections, contact cards, and learning
-          experiments.
-        </p>
-        <div className="actions">
-          <a className="primary-action" href="mailto:aeksandar.kitipov@gmail.com">
-            Свържи се / Get in touch
-          </a>
-          <a className="secondary-action" href="docs/legacy/index.html">
-            View legacy archive
-          </a>
-        </div>
-      </section>
-    </main>
+        <Routes>
+          <Route path={routes.home} element={<HomePage />} />
+          <Route path={routes.about} element={<AboutPage />} />
+          <Route path={routes.projects} element={<ProjectsPage />} />
+          <Route path={routes.projectDetail} element={<ProjectDetailPage />} />
+          <Route path={routes.skills} element={<SkillsPage />} />
+          <Route path={routes.blog} element={<BlogPage />} />
+          <Route path={routes.contact} element={<ContactPage />} />
+          <Route path={routes.links} element={<LinksPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </main>
+    </BrowserRouter>
   );
 }
 

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,0 +1,17 @@
+import { routes } from '../utils/routes';
+
+type NavigationItem = {
+  to: string;
+  label: string;
+  end?: boolean;
+};
+
+export const navigationItems: readonly NavigationItem[] = [
+  { to: routes.home, label: 'Home', end: true },
+  { to: routes.about, label: 'About' },
+  { to: routes.projects, label: 'Projects' },
+  { to: routes.skills, label: 'Skills' },
+  { to: routes.blog, label: 'Blog' },
+  { to: routes.contact, label: 'Contact' },
+  { to: routes.links, label: 'Links' },
+];

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,0 +1,18 @@
+function AboutPage() {
+  return (
+    <section className="page-card" aria-labelledby="page-title">
+      <p className="eyebrow">About</p>
+      <h1 id="page-title">About Aleksandar Kitipov</h1>
+      <p className="intro">
+        A dedicated space for the personal story, learning journey, and professional
+        goals behind this portfolio.
+      </p>
+      <p className="page-note">
+        Future content will highlight background, values, education, and the evolution
+        from the legacy static website to this React application.
+      </p>
+    </section>
+  );
+}
+
+export default AboutPage;

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,0 +1,17 @@
+function BlogPage() {
+  return (
+    <section className="page-card" aria-labelledby="page-title">
+      <p className="eyebrow">Blog</p>
+      <h1 id="page-title">Notes and Articles</h1>
+      <p className="intro">
+        A routed writing shell for development notes, algorithms, tutorials, and project
+        retrospectives.
+      </p>
+      <p className="page-note">
+        Blog entries can later be backed by markdown, a CMS, or typed local content.
+      </p>
+    </section>
+  );
+}
+
+export default BlogPage;

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,0 +1,19 @@
+function ContactPage() {
+  return (
+    <section className="page-card" aria-labelledby="page-title">
+      <p className="eyebrow">Contact</p>
+      <h1 id="page-title">Contact Aleksandar</h1>
+      <p className="intro">
+        A contact page shell for email, social profiles, collaboration notes, and
+        availability.
+      </p>
+      <div className="actions">
+        <a className="primary-action" href="mailto:aeksandar.kitipov@gmail.com">
+          Send email
+        </a>
+      </div>
+    </section>
+  );
+}
+
+export default ContactPage;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom';
+import { routes } from '../utils/routes';
+
+function HomePage() {
+  return (
+    <section className="page-card hero-card" aria-labelledby="page-title">
+      <p className="eyebrow">Portfolio home</p>
+      <h1 id="page-title">Алгоритъмът на деня | Algorithm of the Day</h1>
+      <p className="intro">
+        Welcome to Aleksandar Kitipov&apos;s modern portfolio hub for projects, skills,
+        writing, and learning experiments.
+      </p>
+      <p className="intro">
+        This shell keeps the original educational spirit of the legacy site while
+        introducing routed React sections for the next build milestones.
+      </p>
+      <div className="actions">
+        <Link className="primary-action" to={routes.projects}>
+          Explore projects
+        </Link>
+        <Link className="secondary-action" to={routes.contact}>
+          Get in touch
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export default HomePage;

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -1,0 +1,18 @@
+function LinksPage() {
+  return (
+    <section className="page-card" aria-labelledby="page-title">
+      <p className="eyebrow">Links</p>
+      <h1 id="page-title">Useful Links</h1>
+      <p className="intro">
+        A page shell for external profiles, learning resources, legacy pages, and
+        reference material.
+      </p>
+      <div className="content-list" aria-label="Legacy reference links">
+        <a href="docs/legacy/index.html">Legacy archive</a>
+        <a href="docs/legacy/links.html">Original links page</a>
+      </div>
+    </section>
+  );
+}
+
+export default LinksPage;

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+import { routes } from '../utils/routes';
+
+function NotFoundPage() {
+  return (
+    <section className="page-card" aria-labelledby="page-title">
+      <p className="eyebrow">404</p>
+      <h1 id="page-title">Page not found</h1>
+      <p className="intro">
+        The route you requested does not exist in the portfolio yet.
+      </p>
+      <Link className="primary-action" to={routes.home}>
+        Return home
+      </Link>
+    </section>
+  );
+}
+
+export default NotFoundPage;

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,26 @@
+import { Link, useParams } from 'react-router-dom';
+import { routes } from '../utils/routes';
+
+function ProjectDetailPage() {
+  const { projectId } = useParams();
+  const displayName = projectId?.replaceAll('-', ' ') ?? 'selected project';
+
+  return (
+    <section className="page-card" aria-labelledby="page-title">
+      <p className="eyebrow">Project detail</p>
+      <h1 id="page-title">Project: {displayName}</h1>
+      <p className="intro">
+        This detail shell confirms dynamic routing for individual portfolio projects.
+      </p>
+      <p className="page-note">
+        Case studies, screenshots, technology notes, and repository links can be added
+        here as project data is introduced.
+      </p>
+      <Link className="text-action" to={routes.projects}>
+        Back to all projects
+      </Link>
+    </section>
+  );
+}
+
+export default ProjectDetailPage;

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom';
+import { getProjectDetailPath } from '../utils/routes';
+
+function ProjectsPage() {
+  return (
+    <section className="page-card" aria-labelledby="page-title">
+      <p className="eyebrow">Projects</p>
+      <h1 id="page-title">Portfolio Projects</h1>
+      <p className="intro">
+        A routed project index shell for featured applications, experiments, and
+        algorithm practice.
+      </p>
+      <div className="content-list" aria-label="Sample project links">
+        <Link to={getProjectDetailPath('algorithm-of-the-day')}>Algorithm of the Day</Link>
+        <Link to={getProjectDetailPath('portfolio-foundation')}>Portfolio Foundation</Link>
+      </div>
+    </section>
+  );
+}
+
+export default ProjectsPage;

--- a/src/pages/SkillsPage.tsx
+++ b/src/pages/SkillsPage.tsx
@@ -1,0 +1,17 @@
+function SkillsPage() {
+  return (
+    <section className="page-card" aria-labelledby="page-title">
+      <p className="eyebrow">Skills</p>
+      <h1 id="page-title">Technical Skills</h1>
+      <p className="intro">
+        A page shell for languages, frameworks, tools, and learning milestones.
+      </p>
+      <p className="page-note">
+        Future iterations can group skills by frontend, backend, tooling, design, and
+        problem-solving experience.
+      </p>
+    </section>
+  );
+}
+
+export default SkillsPage;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -157,3 +157,62 @@ h1 {
   box-shadow: 0 12px 32px rgba(96, 165, 250, 0.28);
   transform: translateY(-2px);
 }
+
+.top-nav a.active {
+  background: rgba(96, 165, 250, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(191, 219, 254, 0.35);
+  color: #ffffff;
+}
+
+.page-card {
+  backdrop-filter: blur(16px);
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(226, 232, 240, 0.2);
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 80px rgba(2, 6, 23, 0.45);
+  max-width: 760px;
+  padding: clamp(2rem, 5vw, 3.5rem);
+  text-align: center;
+  width: min(100%, 760px);
+}
+
+.page-note {
+  color: #bfdbfe;
+  font-size: 1rem;
+  margin: 1rem auto 0;
+  max-width: 60ch;
+}
+
+.content-list {
+  display: grid;
+  gap: 0.85rem;
+  margin: 2rem auto 0;
+  max-width: 28rem;
+}
+
+.content-list a,
+.text-action {
+  border: 1px solid rgba(226, 232, 240, 0.25);
+  border-radius: 1rem;
+  color: #dbeafe;
+  display: block;
+  font-weight: 800;
+  padding: 0.85rem 1rem;
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.content-list a:hover,
+.content-list a:focus-visible,
+.text-action:hover,
+.text-action:focus-visible {
+  background: rgba(96, 165, 250, 0.16);
+  transform: translateY(-1px);
+}
+
+.text-action {
+  display: inline-block;
+  margin-top: 1.5rem;
+}

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,0 +1,16 @@
+export const routes = {
+  home: '/',
+  about: '/about',
+  projects: '/projects',
+  projectDetail: '/projects/:projectId',
+  skills: '/skills',
+  blog: '/blog',
+  contact: '/contact',
+  links: '/links',
+} as const;
+
+export type AppRouteKey = keyof typeof routes;
+
+export function getProjectDetailPath(projectId: string) {
+  return routes.projectDetail.replace(':projectId', projectId);
+}


### PR DESCRIPTION
### Motivation
- Introduce client-side routing and initial page scaffolds so the portfolio can grow into distinct sections (Home, About, Projects, etc.) with deep links and dynamic project pages.
- Keep route definitions centralized for consistent linking and future data-driven pages.

### Description
- Added `react-router-dom` to `package.json` and updated `src/App.tsx` to use `BrowserRouter`, `NavLink`, `Routes`, and `Route` to declare all portfolio routes and a wildcard `NotFoundPage`.
- Created route constants and a helper in `src/utils/routes.ts` and a typed navigation list in `src/data/navigation.ts` to drive the top navigation and route links.
- Added page shell components for each section in `src/pages/*` (`HomePage`, `AboutPage`, `ProjectsPage`, `ProjectDetailPage`, `SkillsPage`, `BlogPage`, `ContactPage`, `LinksPage`, `NotFoundPage`) with unique titles and content placeholders.
- Extended styles in `src/styles/globals.css` for active navigation state and reusable page shell UI (`.page-card`, `.content-list`, `.page-note`, etc.).

### Testing
- Ran `git diff --check` which reported no problems and completed successfully.
- Ran `npm run typecheck` which failed due to missing or unresolved dependencies in the execution environment (TypeScript reported missing modules such as `react` and `react-router-dom`).
- Ran `npm run lint` which failed because ESLint could not resolve required packages (error importing `@eslint/js`) in this environment.
- Attempted `npm install` to fetch dependencies but the environment blocked registry access (403 / proxy restrictions), so runtime/typecheck/linting are currently blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f02616ac8330be3a4e26d5613020)