### PR TITLE
Convert legacy portfolio content into typed data

### DIFF
--- a/src/data/algorithmOfTheDay.ts
+++ b/src/data/algorithmOfTheDay.ts
@@ -1,0 +1,69 @@
+import type { EpisodeFormatStep } from '../types/blog';
+import type { Project } from '../types/project';
+
+export const algorithmOfTheDayProject: Project = {
+  id: 'algorithm-of-the-day',
+  title: 'Алгоритъмът на деня | Algorithm of the Day',
+  subtitle: 'A ritual media experiment where people and algorithms learn together.',
+  summary:
+    'An educational web page, digital business card, and creative learning prototype created by Aleksandar Kitipov with AI collaborators.',
+  description:
+    'Algorithm of the Day turns current facts, news, and ideas into concise poetic rituals that combine commentary, metaphor, music, and a question for the community.',
+  status: 'featured',
+  featured: true,
+  tags: ['AI collaboration', 'Education', 'Media ritual', 'Community', 'Prototype'],
+  highlights: [
+    'Frames Aleksandar as the conductor and architect of the project vision.',
+    'Combines facts, metaphors, rituals, music, and community prompts into an episode format.',
+    'Preserves the educational spirit of the original Notepad++ static website while moving toward typed React content.',
+  ],
+  links: [
+    {
+      label: 'GitHub repository',
+      url: 'https://github.com/AlexKitipov/-Algorithm-of-the-Day-',
+      kind: 'repository',
+      isPublic: true,
+    },
+    {
+      label: 'Google Colab notebook',
+      url: 'https://colab.research.google.com/drive/1QFMujrV8aajNQTwUCzmd_V74PKa_2e4L#scrollTo=eba04bcd',
+      kind: 'notebook',
+      isPublic: true,
+    },
+  ],
+};
+
+export const episodeFormat: readonly EpisodeFormatStep[] = [
+  {
+    title: 'Prologue',
+    description: 'A short sound or musical motif that opens the episode.',
+  },
+  {
+    title: 'Fact',
+    description: 'A current news item, idea, or piece of knowledge.',
+  },
+  {
+    title: 'Metaphor',
+    description: 'A translation of the fact into an image, legend, or poetic frame.',
+  },
+  {
+    title: 'Ritual',
+    description: 'A small action listeners can try or reflect on.',
+  },
+  {
+    title: 'Music',
+    description: 'A song or playlist connected to the theme.',
+  },
+  {
+    title: 'Community question',
+    description: 'A prompt whose responses can shape the next episode.',
+  },
+];
+
+export const projectArchiveStructure = [
+  '/episodes/ — Markdown episode scripts',
+  '/audio/ — completed MP3 audio recordings',
+  '/journal/ — CSV episode index',
+  '/community/ — collected responses and comments',
+  '/assets/ — musical motifs and graphics',
+] as const;

--- a/src/data/biography.ts
+++ b/src/data/biography.ts
@@ -1,0 +1,16 @@
+export const biography = {
+  name: 'Aleksandar Kitipov',
+  title: 'Conductor and architect of Algorithm of the Day',
+  birthplace: 'Plovdiv, Bulgaria',
+  birthYear: 1976,
+  overview:
+    'Aleksandar Kitipov was born in Plovdiv, Bulgaria, where he completed primary and secondary education. This portfolio presents his learning journey, project work, and the evolution from a legacy static website to a routed React application.',
+  role: 'He creates the structure, vision, and rituals that turn technical elements into a living educational media format.',
+  collaborators: [
+    'Copilot — scriptwriter and commentator',
+    'Gemini — generator of text, code, and data',
+    'Community — listeners and participants',
+  ],
+  philosophy:
+    'Algorithm of the Day is a living stage where algorithms and people create a new type of media together: not just information, but a ritual of knowledge and music.',
+} as const;

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,33 @@
+import { algorithmOfTheDayProject } from './algorithmOfTheDay';
+import type { Project } from '../types/project';
+
+export const projects: readonly Project[] = [
+  algorithmOfTheDayProject,
+  {
+    id: 'portfolio-foundation',
+    title: 'Portfolio Foundation',
+    subtitle: 'A modern React shell for reusable personal content.',
+    summary:
+      'The current routed portfolio application that preserves legacy content while preparing for future project, skills, blog, and contact milestones.',
+    description:
+      'Portfolio Foundation introduces typed local data, route-based pages, responsive cards, and safe public contact defaults for the next publishing iterations.',
+    status: 'active',
+    tags: ['React', 'TypeScript', 'Vite', 'Portfolio'],
+    highlights: [
+      'Migrates static legacy content into reusable modules.',
+      'Separates private contact information from rendered public channels.',
+      'Creates a maintainable base for project case studies and future writing.',
+    ],
+    links: [
+      {
+        label: 'Legacy archive',
+        url: '/docs/legacy/index.html',
+        kind: 'archive',
+        isPublic: false,
+      },
+    ],
+  },
+];
+
+export const featuredProject =
+  projects.find((project) => project.featured) ?? projects[0];

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,88 @@
+import type { SkillGroup } from '../types/skill';
+
+export const skillGroups: readonly SkillGroup[] = [
+  {
+    title: 'Languages and foundations',
+    description: 'Core languages and concepts used across learning prototypes.',
+    skills: [
+      {
+        name: 'HTML and semantic structure',
+        category: 'language',
+        level: 'building',
+        summary:
+          'Used in the original static pages and carried forward into accessible React markup.',
+      },
+      {
+        name: 'CSS and responsive presentation',
+        category: 'frontend',
+        level: 'practicing',
+        summary:
+          'Supports the portfolio background, cards, lists, and readable content sections.',
+      },
+      {
+        name: 'JavaScript and TypeScript',
+        category: 'language',
+        level: 'practicing',
+        summary:
+          'Used to convert page shells into typed reusable data and route-aware components.',
+      },
+      {
+        name: 'Python learning environment',
+        category: 'language',
+        level: 'learning',
+        summary:
+          'Explored through Google Colab and algorithm-oriented learning resources.',
+      },
+    ],
+  },
+  {
+    title: 'Tools and workflow',
+    description: 'Editors, platforms, and habits represented in the legacy content.',
+    skills: [
+      {
+        name: 'React and Vite',
+        category: 'frontend',
+        level: 'building',
+        summary: 'Power the modern routed portfolio application.',
+      },
+      {
+        name: 'GitHub project publishing',
+        category: 'tooling',
+        level: 'practicing',
+        summary: 'Hosts code, project links, and the GitHub Pages portfolio workflow.',
+      },
+      {
+        name: 'Notepad++ and browser prototyping',
+        category: 'tooling',
+        level: 'building',
+        summary: 'Part of the original website origin story and educational workflow.',
+      },
+      {
+        name: 'AI-assisted collaboration',
+        category: 'collaboration',
+        level: 'building',
+        summary:
+          'Uses Copilot and Gemini as creative partners for text, code, data, and commentary.',
+      },
+    ],
+  },
+  {
+    title: 'Creative media practice',
+    description: 'Skills tied to the Algorithm of the Day format.',
+    skills: [
+      {
+        name: 'Episode design',
+        category: 'creative',
+        level: 'practicing',
+        summary:
+          'Shapes prologue, fact, metaphor, ritual, music, and community question segments.',
+      },
+      {
+        name: 'Community prompts',
+        category: 'creative',
+        level: 'learning',
+        summary: 'Turns listener participation into material for future episodes.',
+      },
+    ],
+  },
+];

--- a/src/data/socialLinks.ts
+++ b/src/data/socialLinks.ts
@@ -1,0 +1,122 @@
+import type { ContactChannel, SocialLink } from '../types/contact';
+
+export const contactChannels: readonly ContactChannel[] = [
+  {
+    label: 'Preferred public email',
+    value: 'aeksandar.kitipov@gmail.com',
+    href: 'mailto:aeksandar.kitipov@gmail.com',
+    kind: 'email',
+    visibility: 'public',
+    note: 'Safe default from the legacy site; confirm this remains the preferred publishing email.',
+  },
+  {
+    label: 'Outlook email',
+    value: 'aeksandar.kitipov@outlook.com',
+    kind: 'email',
+    visibility: 'private',
+    note: 'Legacy address retained in data for review but not rendered publicly.',
+  },
+  {
+    label: 'ABV email',
+    value: 'aleksandar.kitipov@abv.bg',
+    kind: 'email',
+    visibility: 'private',
+    note: 'Legacy address retained in data for review but not rendered publicly.',
+  },
+  {
+    label: 'Phone',
+    value: 'Private phone number from legacy contacts',
+    kind: 'phone',
+    visibility: 'private',
+    note: 'Do not render until Aleksandar confirms that a phone number should be public.',
+  },
+  {
+    label: 'Address',
+    value: 'Private street address from legacy contacts',
+    kind: 'location',
+    visibility: 'private',
+    note: 'Sensitive street address intentionally excluded from rendering.',
+  },
+  {
+    label: 'Location',
+    value: 'Plovdiv, Bulgaria',
+    kind: 'location',
+    visibility: 'public',
+    note: 'City-level location only.',
+  },
+];
+
+export const publicContactChannels = contactChannels.filter(
+  (channel) => channel.visibility === 'public',
+);
+
+export const socialLinks: readonly SocialLink[] = [
+  {
+    label: 'Algorithm of the Day on GitHub',
+    url: 'https://github.com/AlexKitipov/-Algorithm-of-the-Day-',
+    kind: 'github',
+    isPublic: true,
+    description: 'Primary public project repository from the legacy site.',
+  },
+  {
+    label: 'Google Colab notebook',
+    url: 'https://colab.research.google.com/drive/1QFMujrV8aajNQTwUCzmd_V74PKa_2e4L#scrollTo=eba04bcd',
+    kind: 'learning',
+    isPublic: true,
+    description:
+      'Cloud notebook connected to the Algorithm of the Day learning workflow.',
+  },
+  {
+    label: 'Facebook profile name',
+    url: 'https://www.facebook.com/',
+    kind: 'facebook',
+    isPublic: false,
+    description:
+      'Legacy content listed the name “Aleksandar Kitipov”; no profile URL is published until confirmed.',
+  },
+  {
+    label: 'Copilot Microsoft',
+    url: 'https://copilot.microsoft.com',
+    kind: 'tool',
+    isPublic: true,
+    description: 'AI assistant referenced as a collaborator in the legacy pages.',
+  },
+  {
+    label: 'GitHub',
+    url: 'https://github.com/',
+    kind: 'tool',
+    isPublic: true,
+    description: 'Platform for code and projects.',
+  },
+  {
+    label: 'Google Colab',
+    url: 'https://colab.research.google.com/',
+    kind: 'tool',
+    isPublic: true,
+    description: 'Cloud environment for Python learning.',
+  },
+  {
+    label: 'Notepad++',
+    url: 'https://notepad-plus-plus.org/',
+    kind: 'tool',
+    isPublic: true,
+    description: 'Editor used in the legacy site origin story.',
+  },
+  {
+    label: 'Python.org',
+    url: 'https://www.python.org/',
+    kind: 'tool',
+    isPublic: true,
+    description: 'Official Python learning resource.',
+  },
+  {
+    label: 'Legacy archive',
+    url: '/docs/legacy/index.html',
+    kind: 'legacy',
+    isPublic: false,
+    description:
+      'Archived static pages are retained for local review only because they contain private contact details.',
+  },
+];
+
+export const publicSocialLinks = socialLinks.filter((link) => link.isPublic);

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,16 +1,44 @@
+import { biography } from '../data/biography';
+import { episodeFormat, projectArchiveStructure } from '../data/algorithmOfTheDay';
+
 function AboutPage() {
   return (
     <section className="page-card" aria-labelledby="page-title">
       <p className="eyebrow">About</p>
-      <h1 id="page-title">About Aleksandar Kitipov</h1>
-      <p className="intro">
-        A dedicated space for the personal story, learning journey, and professional
-        goals behind this portfolio.
-      </p>
-      <p className="page-note">
-        Future content will highlight background, values, education, and the evolution
-        from the legacy static website to this React application.
-      </p>
+      <h1 id="page-title">About {biography.name}</h1>
+      <p className="intro">{biography.overview}</p>
+
+      <div className="section-stack">
+        <article className="info-panel">
+          <h2>{biography.title}</h2>
+          <p>{biography.role}</p>
+          <ul>
+            {biography.collaborators.map((collaborator) => (
+              <li key={collaborator}>{collaborator}</li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="info-panel">
+          <h2>Episode format</h2>
+          <ol>
+            {episodeFormat.map((step) => (
+              <li key={step.title}>
+                <strong>{step.title}:</strong> {step.description}
+              </li>
+            ))}
+          </ol>
+        </article>
+
+        <article className="info-panel">
+          <h2>Archive structure</h2>
+          <ul>
+            {projectArchiveStructure.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </article>
+      </div>
     </section>
   );
 }

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,17 +1,38 @@
+import { publicContactChannels } from '../data/socialLinks';
+
 function ContactPage() {
+  const primaryEmail = publicContactChannels.find(
+    (channel) => channel.kind === 'email',
+  );
+
   return (
     <section className="page-card" aria-labelledby="page-title">
       <p className="eyebrow">Contact</p>
       <h1 id="page-title">Contact Aleksandar</h1>
       <p className="intro">
-        A contact page shell for email, social profiles, collaboration notes, and
-        availability.
+        Public contact details use safe defaults. Legacy phone numbers and street
+        address data are marked private and are not rendered here.
       </p>
-      <div className="actions">
-        <a className="primary-action" href="mailto:aeksandar.kitipov@gmail.com">
-          Send email
-        </a>
+      <div className="section-stack">
+        {publicContactChannels.map((channel) => (
+          <article className="info-panel" key={`${channel.kind}-${channel.value}`}>
+            <h2>{channel.label}</h2>
+            {channel.href ? (
+              <a href={channel.href}>{channel.value}</a>
+            ) : (
+              <p>{channel.value}</p>
+            )}
+            {channel.note ? <p className="page-note">{channel.note}</p> : null}
+          </article>
+        ))}
       </div>
+      {primaryEmail?.href ? (
+        <div className="actions">
+          <a className="primary-action" href={primaryEmail.href}>
+            Send email
+          </a>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,22 +1,18 @@
 import { Link } from 'react-router-dom';
-import { routes } from '../utils/routes';
+import { biography } from '../data/biography';
+import { featuredProject } from '../data/projects';
+import { routes, getProjectDetailPath } from '../utils/routes';
 
 function HomePage() {
   return (
     <section className="page-card hero-card" aria-labelledby="page-title">
       <p className="eyebrow">Portfolio home</p>
-      <h1 id="page-title">Алгоритъмът на деня | Algorithm of the Day</h1>
-      <p className="intro">
-        Welcome to Aleksandar Kitipov&apos;s modern portfolio hub for projects, skills,
-        writing, and learning experiments.
-      </p>
-      <p className="intro">
-        This shell keeps the original educational spirit of the legacy site while
-        introducing routed React sections for the next build milestones.
-      </p>
+      <h1 id="page-title">{featuredProject.title}</h1>
+      <p className="intro">{featuredProject.summary}</p>
+      <p className="intro">{biography.philosophy}</p>
       <div className="actions">
-        <Link className="primary-action" to={routes.projects}>
-          Explore projects
+        <Link className="primary-action" to={getProjectDetailPath(featuredProject.id)}>
+          Explore featured project
         </Link>
         <Link className="secondary-action" to={routes.contact}>
           Get in touch

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -1,15 +1,21 @@
+import { publicSocialLinks } from '../data/socialLinks';
+
 function LinksPage() {
   return (
     <section className="page-card" aria-labelledby="page-title">
       <p className="eyebrow">Links</p>
       <h1 id="page-title">Useful Links</h1>
       <p className="intro">
-        A page shell for external profiles, learning resources, legacy pages, and
-        reference material.
+        External profiles, learning resources, legacy pages, and reference material are
+        rendered from public typed link data.
       </p>
-      <div className="content-list" aria-label="Legacy reference links">
-        <a href="docs/legacy/index.html">Legacy archive</a>
-        <a href="docs/legacy/links.html">Original links page</a>
+      <div className="content-list" aria-label="Public reference links">
+        {publicSocialLinks.map((link) => (
+          <a key={link.label} href={link.url} rel="noreferrer" target="_blank">
+            <span>{link.label}</span>
+            {link.description ? <small>{link.description}</small> : null}
+          </a>
+        ))}
       </div>
     </section>
   );

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -1,21 +1,63 @@
 import { Link, useParams } from 'react-router-dom';
+import { projects } from '../data/projects';
 import { routes } from '../utils/routes';
 
 function ProjectDetailPage() {
   const { projectId } = useParams();
-  const displayName = projectId?.replaceAll('-', ' ') ?? 'selected project';
+  const project = projects.find((item) => item.id === projectId);
+
+  if (!project) {
+    return (
+      <section className="page-card" aria-labelledby="page-title">
+        <p className="eyebrow">Project detail</p>
+        <h1 id="page-title">Project not found</h1>
+        <p className="intro">
+          The requested project does not exist in the typed project data.
+        </p>
+        <Link className="text-action" to={routes.projects}>
+          Back to all projects
+        </Link>
+      </section>
+    );
+  }
+
+  const publicLinks = project.links.filter((link) => link.isPublic);
 
   return (
     <section className="page-card" aria-labelledby="page-title">
       <p className="eyebrow">Project detail</p>
-      <h1 id="page-title">Project: {displayName}</h1>
-      <p className="intro">
-        This detail shell confirms dynamic routing for individual portfolio projects.
-      </p>
-      <p className="page-note">
-        Case studies, screenshots, technology notes, and repository links can be added
-        here as project data is introduced.
-      </p>
+      <h1 id="page-title">{project.title}</h1>
+      <p className="intro">{project.description}</p>
+
+      <div className="section-stack">
+        <article className="info-panel">
+          <h2>Highlights</h2>
+          <ul>
+            {project.highlights.map((highlight) => (
+              <li key={highlight}>{highlight}</li>
+            ))}
+          </ul>
+          <div className="tag-list" aria-label={`${project.title} tags`}>
+            {project.tags.map((tag) => (
+              <span key={tag}>{tag}</span>
+            ))}
+          </div>
+        </article>
+
+        {publicLinks.length > 0 ? (
+          <article className="info-panel">
+            <h2>Public links</h2>
+            <div className="content-list compact-list">
+              {publicLinks.map((link) => (
+                <a key={link.url} href={link.url} rel="noreferrer" target="_blank">
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          </article>
+        ) : null}
+      </div>
+
       <Link className="text-action" to={routes.projects}>
         Back to all projects
       </Link>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { projects } from '../data/projects';
 import { getProjectDetailPath } from '../utils/routes';
 
 function ProjectsPage() {
@@ -7,12 +8,26 @@ function ProjectsPage() {
       <p className="eyebrow">Projects</p>
       <h1 id="page-title">Portfolio Projects</h1>
       <p className="intro">
-        A routed project index shell for featured applications, experiments, and
-        algorithm practice.
+        Featured applications, experiments, and algorithm practice are now backed by
+        reusable typed project data.
       </p>
-      <div className="content-list" aria-label="Sample project links">
-        <Link to={getProjectDetailPath('algorithm-of-the-day')}>Algorithm of the Day</Link>
-        <Link to={getProjectDetailPath('portfolio-foundation')}>Portfolio Foundation</Link>
+      <div className="card-grid" aria-label="Project links">
+        {projects.map((project) => (
+          <article className="info-panel" key={project.id}>
+            <p className="status-label">{project.status}</p>
+            <h2>{project.title}</h2>
+            {project.subtitle ? <p>{project.subtitle}</p> : null}
+            <p>{project.summary}</p>
+            <div className="tag-list" aria-label={`${project.title} tags`}>
+              {project.tags.map((tag) => (
+                <span key={tag}>{tag}</span>
+              ))}
+            </div>
+            <Link className="text-action" to={getProjectDetailPath(project.id)}>
+              View project
+            </Link>
+          </article>
+        ))}
       </div>
     </section>
   );

--- a/src/pages/SkillsPage.tsx
+++ b/src/pages/SkillsPage.tsx
@@ -1,15 +1,31 @@
+import { skillGroups } from '../data/skills';
+
 function SkillsPage() {
   return (
     <section className="page-card" aria-labelledby="page-title">
       <p className="eyebrow">Skills</p>
       <h1 id="page-title">Technical Skills</h1>
       <p className="intro">
-        A page shell for languages, frameworks, tools, and learning milestones.
+        Languages, tools, workflows, and creative practices extracted from the legacy
+        portfolio into typed data groups.
       </p>
-      <p className="page-note">
-        Future iterations can group skills by frontend, backend, tooling, design, and
-        problem-solving experience.
-      </p>
+      <div className="section-stack">
+        {skillGroups.map((group) => (
+          <article className="info-panel" key={group.title}>
+            <h2>{group.title}</h2>
+            <p>{group.description}</p>
+            <div className="skill-list">
+              {group.skills.map((skill) => (
+                <div key={skill.name}>
+                  <strong>{skill.name}</strong>
+                  <span>{skill.level}</span>
+                  <p>{skill.summary}</p>
+                </div>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -216,3 +216,119 @@ h1 {
   display: inline-block;
   margin-top: 1.5rem;
 }
+
+.section-stack {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+  text-align: left;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+  text-align: left;
+}
+
+.info-panel {
+  background: rgba(15, 23, 42, 0.46);
+  border: 1px solid rgba(226, 232, 240, 0.18);
+  border-radius: 1.1rem;
+  padding: 1.2rem;
+}
+
+.info-panel h2 {
+  color: #bfdbfe;
+  font-size: 1.2rem;
+  margin: 0 0 0.75rem;
+}
+
+.info-panel p {
+  color: #dbeafe;
+  margin: 0 0 0.75rem;
+}
+
+.info-panel p:last-child {
+  margin-bottom: 0;
+}
+
+.info-panel a {
+  color: #93c5fd;
+  font-weight: 800;
+}
+
+.info-panel ul,
+.info-panel ol {
+  color: #dbeafe;
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.info-panel li + li {
+  margin-top: 0.45rem;
+}
+
+.status-label {
+  color: #93c5fd !important;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.tag-list span,
+.skill-list span {
+  background: rgba(96, 165, 250, 0.16);
+  border: 1px solid rgba(147, 197, 253, 0.28);
+  border-radius: 999px;
+  color: #dbeafe;
+  font-size: 0.8rem;
+  font-weight: 800;
+  padding: 0.25rem 0.6rem;
+}
+
+.skill-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.skill-list > div {
+  border-top: 1px solid rgba(226, 232, 240, 0.14);
+  display: grid;
+  gap: 0.4rem;
+  padding-top: 0.85rem;
+}
+
+.skill-list strong {
+  color: #ffffff;
+}
+
+.content-list a small {
+  color: #bfdbfe;
+  display: block;
+  font-weight: 600;
+  margin-top: 0.25rem;
+}
+
+.compact-list {
+  margin-top: 0.5rem;
+}
+
+@media (min-width: 860px) {
+  .page-card {
+    max-width: 920px;
+    width: min(100%, 920px);
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,0 +1,15 @@
+export type BlogPostStatus = 'draft' | 'planned' | 'published';
+
+export type BlogPost = {
+  id: string;
+  title: string;
+  summary: string;
+  status: BlogPostStatus;
+  tags: readonly string[];
+  relatedProjectId?: string;
+};
+
+export type EpisodeFormatStep = {
+  title: string;
+  description: string;
+};

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -1,0 +1,18 @@
+export type ContactVisibility = 'public' | 'private';
+
+export type ContactChannel = {
+  label: string;
+  value: string;
+  href?: string;
+  kind: 'email' | 'phone' | 'location' | 'social' | 'website' | 'messaging';
+  visibility: ContactVisibility;
+  note?: string;
+};
+
+export type SocialLink = {
+  label: string;
+  url: string;
+  kind: 'github' | 'facebook' | 'learning' | 'tool' | 'legacy' | 'other';
+  isPublic: boolean;
+  description?: string;
+};

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,21 @@
+export type ProjectStatus = 'featured' | 'active' | 'archived' | 'planned';
+
+export type ProjectLink = {
+  label: string;
+  url: string;
+  kind: 'repository' | 'notebook' | 'demo' | 'archive' | 'resource';
+  isPublic: boolean;
+};
+
+export type Project = {
+  id: string;
+  title: string;
+  subtitle?: string;
+  summary: string;
+  description: string;
+  status: ProjectStatus;
+  tags: readonly string[];
+  highlights: readonly string[];
+  links: readonly ProjectLink[];
+  featured?: boolean;
+};

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -1,0 +1,20 @@
+export type SkillLevel = 'learning' | 'practicing' | 'building';
+
+export type Skill = {
+  name: string;
+  category:
+    | 'language'
+    | 'frontend'
+    | 'tooling'
+    | 'workflow'
+    | 'collaboration'
+    | 'creative';
+  level: SkillLevel;
+  summary: string;
+};
+
+export type SkillGroup = {
+  title: string;
+  description: string;
+  skills: readonly Skill[];
+};


### PR DESCRIPTION
### Motivation
- Move legacy static content into a maintainable, typed data layer so pages can render from reusable data models. 
- Preserve the "Algorithm of the Day" project as a featured project and capture episode/archive metadata. 
- Protect personal information by excluding or flagging sensitive contact details as private and rendering only safe public defaults.

### Description
- Added TypeScript models in `src/types/` for projects, skills, contact/social links, and blog/episode metadata (`project.ts`, `skill.ts`, `contact.ts`, `blog.ts`).
- Created typed data modules in `src/data/` for biography, projects, skills, social links, and the Algorithm of the Day (`biography.ts`, `projects.ts`, `skills.ts`, `socialLinks.ts`, `algorithmOfTheDay.ts`).
- Refactored pages to consume the typed data instead of hard-coded strings: `HomePage.tsx`, `AboutPage.tsx`, `ProjectsPage.tsx`, `SkillsPage.tsx`, `ContactPage.tsx`, `LinksPage.tsx`, and `ProjectDetailPage.tsx` now render from the new data modules and filter public/private channels.
- Marked sensitive entries (secondary emails, phone, street address, Facebook profile name, and legacy archive link) as `private`/non-public in data and ensured only `public` items are rendered; added UI grouping and card/list styles in `src/styles/globals.css` to support the new structured content.

### Testing
- Ran formatting checks with `prettier --check` on the modified files and fixed style issues; the Prettier checks passed after formatting.
- Ran `git diff --check` and a sensitive-content scan using `rg` to search for legacy phone/address/email patterns; matches moved into data and are intentionally flagged `private` so they are not rendered.
- Attempted dependency installs and type checks: `npm install` failed with an npm registry `403 Forbidden` for `@eslint/js`, therefore `npm run typecheck`, `npm run build`, and `npm run lint` could not complete in this environment due to missing dependencies.  
- All code changes were committed and staged for review; please run `npm install` and `npm run typecheck` locally or in CI to validate the full type/build/lint pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f9a30c3c8330ace1429ec85623c8)