### PR TITLE
Implement polished Home and About pages

### DIFF
--- a/src/components/portfolio/AboutNarrative.tsx
+++ b/src/components/portfolio/AboutNarrative.tsx
@@ -1,0 +1,49 @@
+import { biography } from '../../data/biography';
+
+function AboutNarrative() {
+  return (
+    <div className="about-narrative">
+      <section className="info-panel narrative-lead" aria-labelledby="biography-title">
+        <p className="eyebrow">Biography · Биография</p>
+        <h2 id="biography-title">{biography.name}</h2>
+        <p>{biography.overview}</p>
+        <p>{biography.background}</p>
+      </section>
+
+      <div className="narrative-grid">
+        <article className="info-panel">
+          <h2>Professional role</h2>
+          <p>{biography.role}</p>
+          <ul>
+            {biography.principles.map((principle) => (
+              <li key={principle}>{principle}</li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="info-panel">
+          <h2>Philosophy</h2>
+          <p>{biography.philosophy}</p>
+          <p className="bilingual-line">{biography.bilingualTagline}</p>
+        </article>
+
+        <article className="info-panel">
+          <h2>Collaboration style</h2>
+          <p>{biography.collaborationStyle}</p>
+          <ul>
+            {biography.collaborators.map((collaborator) => (
+              <li key={collaborator}>{collaborator}</li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="info-panel">
+          <h2>Current focus</h2>
+          <p>{biography.currentFocus}</p>
+        </article>
+      </div>
+    </div>
+  );
+}
+
+export default AboutNarrative;

--- a/src/components/portfolio/FeaturedProjects.tsx
+++ b/src/components/portfolio/FeaturedProjects.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router-dom';
+import { featuredProjects } from '../../data/projects';
+import { getProjectDetailPath, routes } from '../../utils/routes';
+
+function FeaturedProjects() {
+  return (
+    <section className="portfolio-section" aria-labelledby="featured-projects-title">
+      <div className="section-heading">
+        <p className="eyebrow">Featured work</p>
+        <h2 id="featured-projects-title">Projects with a clear learning story</h2>
+        <p>
+          Selected work presents the portfolio as both a professional React application
+          and a creative bilingual media experiment.
+        </p>
+      </div>
+      <div className="feature-grid">
+        {featuredProjects.map((project) => (
+          <article className="info-panel feature-card" key={project.id}>
+            <p className="status-label">{project.status}</p>
+            <h3>{project.title}</h3>
+            {project.subtitle ? <p>{project.subtitle}</p> : null}
+            <p>{project.summary}</p>
+            <div className="tag-list" aria-label={`${project.title} tags`}>
+              {project.tags.slice(0, 4).map((tag) => (
+                <span key={tag}>{tag}</span>
+              ))}
+            </div>
+            <Link className="text-action" to={getProjectDetailPath(project.id)}>
+              View case study
+            </Link>
+          </article>
+        ))}
+      </div>
+      <Link className="secondary-action inline-action" to={routes.projects}>
+        Browse all projects
+      </Link>
+    </section>
+  );
+}
+
+export default FeaturedProjects;

--- a/src/components/portfolio/Hero.tsx
+++ b/src/components/portfolio/Hero.tsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom';
+import { biography } from '../../data/biography';
+import { featuredProject } from '../../data/projects';
+import { routes, getProjectDetailPath } from '../../utils/routes';
+
+function Hero() {
+  return (
+    <section className="portfolio-hero" aria-labelledby="page-title">
+      <div className="hero-copy">
+        <p className="eyebrow">Portfolio home · Начало</p>
+        <h1 id="page-title">{biography.name}</h1>
+        <p className="hero-subtitle">{biography.title}</p>
+        <p className="intro">{biography.shortBio}</p>
+        <p className="bilingual-line">{biography.bilingualTagline}</p>
+        <div className="actions hero-actions">
+          <Link className="primary-action" to={getProjectDetailPath(featuredProject.id)}>
+            Explore featured project
+          </Link>
+          <Link className="secondary-action" to={routes.about}>
+            Read the biography
+          </Link>
+        </div>
+      </div>
+      <aside className="hero-highlight" aria-label="Featured focus">
+        <span className="status-label">Current focus</span>
+        <h2>{featuredProject.title}</h2>
+        <p>{featuredProject.summary}</p>
+        <div className="tag-list" aria-label="Featured project tags">
+          {featuredProject.tags.slice(0, 4).map((tag) => (
+            <span key={tag}>{tag}</span>
+          ))}
+        </div>
+      </aside>
+    </section>
+  );
+}
+
+export default Hero;

--- a/src/components/portfolio/SkillsPreview.tsx
+++ b/src/components/portfolio/SkillsPreview.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'react-router-dom';
+import { skillPreviewGroups } from '../../data/skills';
+import { routes } from '../../utils/routes';
+
+function SkillsPreview() {
+  return (
+    <section className="portfolio-section" aria-labelledby="skills-preview-title">
+      <div className="section-heading">
+        <p className="eyebrow">Skills preview</p>
+        <h2 id="skills-preview-title">Practical tools, creative systems</h2>
+        <p>
+          The skill set combines front-end foundations, publishing workflow, and AI-assisted
+          creative practice.
+        </p>
+      </div>
+      <div className="skill-preview-grid">
+        {skillPreviewGroups.map((group) => (
+          <article className="info-panel" key={group.title}>
+            <h3>{group.title}</h3>
+            <p>{group.description}</p>
+            <div className="skill-list compact-skill-list">
+              {group.skills.map((skill) => (
+                <div key={skill.name}>
+                  <strong>{skill.name}</strong>
+                  <span>{skill.level}</span>
+                  <p>{skill.summary}</p>
+                </div>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+      <Link className="secondary-action inline-action" to={routes.skills}>
+        See full skills map
+      </Link>
+    </section>
+  );
+}
+
+export default SkillsPreview;

--- a/src/data/biography.ts
+++ b/src/data/biography.ts
@@ -4,13 +4,27 @@ export const biography = {
   birthplace: 'Plovdiv, Bulgaria',
   birthYear: 1976,
   overview:
-    'Aleksandar Kitipov was born in Plovdiv, Bulgaria, where he completed primary and secondary education. This portfolio presents his learning journey, project work, and the evolution from a legacy static website to a routed React application.',
+    'Aleksandar Kitipov is a Bulgarian creator and lifelong learner building a bilingual portfolio around web publishing, algorithm practice, and AI-assisted creative media.',
+  shortBio:
+    'From Plovdiv to the web, Aleksandar turns learning notes, experiments, and community prompts into clear digital experiences. His work balances structured engineering habits with a poetic signature: knowledge as a daily ritual.',
   role: 'He creates the structure, vision, and rituals that turn technical elements into a living educational media format.',
+  background:
+    'Born in Plovdiv, Bulgaria, Aleksandar completed his primary and secondary education there before moving his curiosity into practical digital projects. The current portfolio preserves the spirit of the original static website while presenting the work through a modern React application.',
+  philosophy:
+    'Algorithm of the Day is a living stage where algorithms and people create a new type of media together: not just information, but a ritual of knowledge and music.',
+  collaborationStyle:
+    'Aleksandar works as a conductor of ideas: he defines the theme, keeps the learning goal visible, and uses AI collaborators for drafting, coding, commentary, and variation while keeping the final direction human-led.',
+  currentFocus:
+    'Current focus: polishing the bilingual portfolio, expanding Algorithm of the Day into repeatable episode formats, and building typed project and skill archives that are easy to maintain.',
+  bilingualTagline: 'Алгоритъмът на деня — knowledge, music, and community in motion.',
   collaborators: [
     'Copilot — scriptwriter and commentator',
     'Gemini — generator of text, code, and data',
     'Community — listeners and participants',
   ],
-  philosophy:
-    'Algorithm of the Day is a living stage where algorithms and people create a new type of media together: not just information, but a ritual of knowledge and music.',
+  principles: [
+    'Professional clarity first; poetic phrasing as a memorable brand accent.',
+    'Typed data and reusable components over one-off page content.',
+    'Learning in public through small, visible, and maintainable iterations.',
+  ],
 } as const;

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -8,7 +8,7 @@ export const projects: readonly Project[] = [
     title: 'Portfolio Foundation',
     subtitle: 'A modern React shell for reusable personal content.',
     summary:
-      'The current routed portfolio application that preserves legacy content while preparing for future project, skills, blog, and contact milestones.',
+      'A routed portfolio application that preserves legacy content while preparing professional project, skills, blog, and contact sections.',
     description:
       'Portfolio Foundation introduces typed local data, route-based pages, responsive cards, and safe public contact defaults for the next publishing iterations.',
     status: 'active',
@@ -27,7 +27,35 @@ export const projects: readonly Project[] = [
       },
     ],
   },
+  {
+    id: 'legacy-learning-archive',
+    title: 'Legacy Learning Archive',
+    subtitle: 'Original static pages preserved as the portfolio origin story.',
+    summary:
+      'A historical snapshot of early HTML pages, contact content, and learning links that informs the current bilingual experience.',
+    description:
+      'The archive keeps the original learning material available while the React portfolio extracts durable content into typed project, biography, and skill data.',
+    status: 'archived',
+    tags: ['HTML', 'Learning archive', 'Migration', 'Documentation'],
+    highlights: [
+      'Documents the transition from hand-authored static pages to reusable React views.',
+      'Preserves screenshots and legacy routes for context without exposing private contact details.',
+      'Provides source material for future biography, links, and project milestones.',
+    ],
+    links: [
+      {
+        label: 'Legacy home page',
+        url: '/docs/legacy/index.html',
+        kind: 'archive',
+        isPublic: true,
+      },
+    ],
+  },
 ];
 
 export const featuredProject =
   projects.find((project) => project.featured) ?? projects[0];
+
+export const featuredProjects = projects.filter(
+  (project) => project.featured || project.status === 'active',
+);

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -24,7 +24,7 @@ export const skillGroups: readonly SkillGroup[] = [
         category: 'language',
         level: 'practicing',
         summary:
-          'Used to convert page shells into typed reusable data and route-aware components.',
+          'Turns page shells into typed reusable data, route-aware components, and maintainable content structures.',
       },
       {
         name: 'Python learning environment',
@@ -43,7 +43,7 @@ export const skillGroups: readonly SkillGroup[] = [
         name: 'React and Vite',
         category: 'frontend',
         level: 'building',
-        summary: 'Power the modern routed portfolio application.',
+        summary: 'Power the modern routed portfolio application and fast local iteration.',
       },
       {
         name: 'GitHub project publishing',
@@ -62,7 +62,7 @@ export const skillGroups: readonly SkillGroup[] = [
         category: 'collaboration',
         level: 'building',
         summary:
-          'Uses Copilot and Gemini as creative partners for text, code, data, and commentary.',
+          'Uses Copilot and Gemini as creative partners for text, code, data, and commentary while preserving human direction.',
       },
     ],
   },
@@ -83,6 +83,18 @@ export const skillGroups: readonly SkillGroup[] = [
         level: 'learning',
         summary: 'Turns listener participation into material for future episodes.',
       },
+      {
+        name: 'Bilingual content framing',
+        category: 'creative',
+        level: 'practicing',
+        summary:
+          'Blends Bulgarian project identity with concise English explanations for a wider audience.',
+      },
     ],
   },
 ];
+
+export const skillPreviewGroups = skillGroups.map((group) => ({
+  ...group,
+  skills: group.skills.slice(0, 2),
+}));

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,45 +1,18 @@
-import { biography } from '../data/biography';
-import { episodeFormat, projectArchiveStructure } from '../data/algorithmOfTheDay';
+import AboutNarrative from '../components/portfolio/AboutNarrative';
 
 function AboutPage() {
   return (
-    <section className="page-card" aria-labelledby="page-title">
-      <p className="eyebrow">About</p>
-      <h1 id="page-title">About {biography.name}</h1>
-      <p className="intro">{biography.overview}</p>
-
-      <div className="section-stack">
-        <article className="info-panel">
-          <h2>{biography.title}</h2>
-          <p>{biography.role}</p>
-          <ul>
-            {biography.collaborators.map((collaborator) => (
-              <li key={collaborator}>{collaborator}</li>
-            ))}
-          </ul>
-        </article>
-
-        <article className="info-panel">
-          <h2>Episode format</h2>
-          <ol>
-            {episodeFormat.map((step) => (
-              <li key={step.title}>
-                <strong>{step.title}:</strong> {step.description}
-              </li>
-            ))}
-          </ol>
-        </article>
-
-        <article className="info-panel">
-          <h2>Archive structure</h2>
-          <ul>
-            {projectArchiveStructure.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        </article>
-      </div>
-    </section>
+    <div className="portfolio-page about-page" aria-labelledby="page-title">
+      <section className="page-card about-hero">
+        <p className="eyebrow">About</p>
+        <h1 id="page-title">About Aleksandar Kitipov</h1>
+        <p className="intro">
+          A concise bilingual profile for a creator shaping Algorithm of the Day,
+          practical web learning, and AI-assisted project publishing.
+        </p>
+      </section>
+      <AboutNarrative />
+    </div>
   );
 }
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,24 +1,50 @@
-import { Link } from 'react-router-dom';
+import FeaturedProjects from '../components/portfolio/FeaturedProjects';
+import Hero from '../components/portfolio/Hero';
+import SkillsPreview from '../components/portfolio/SkillsPreview';
 import { biography } from '../data/biography';
-import { featuredProject } from '../data/projects';
-import { routes, getProjectDetailPath } from '../utils/routes';
+import { publicContactChannels } from '../data/socialLinks';
 
 function HomePage() {
+  const primaryEmail = publicContactChannels.find(
+    (channel) => channel.kind === 'email',
+  );
+
   return (
-    <section className="page-card hero-card" aria-labelledby="page-title">
-      <p className="eyebrow">Portfolio home</p>
-      <h1 id="page-title">{featuredProject.title}</h1>
-      <p className="intro">{featuredProject.summary}</p>
-      <p className="intro">{biography.philosophy}</p>
-      <div className="actions">
-        <Link className="primary-action" to={getProjectDetailPath(featuredProject.id)}>
-          Explore featured project
-        </Link>
-        <Link className="secondary-action" to={routes.contact}>
-          Get in touch
-        </Link>
-      </div>
-    </section>
+    <div className="portfolio-page" aria-label="Portfolio home">
+      <Hero />
+
+      <section
+        className="portfolio-section bio-preview"
+        aria-labelledby="short-bio-title"
+      >
+        <div className="section-heading">
+          <p className="eyebrow">Short bio</p>
+          <h2 id="short-bio-title">Professional structure with a poetic signal</h2>
+          <p>{biography.overview}</p>
+        </div>
+        <p className="intro">{biography.shortBio}</p>
+      </section>
+
+      <FeaturedProjects />
+      <SkillsPreview />
+
+      <section
+        className="portfolio-section contact-cta"
+        aria-labelledby="contact-cta-title"
+      >
+        <p className="eyebrow">Contact CTA</p>
+        <h2 id="contact-cta-title">Build the next learning ritual together</h2>
+        <p>
+          For collaboration, portfolio feedback, or Algorithm of the Day ideas, use the
+          public contact channel and keep the conversation focused on learning in public.
+        </p>
+        {primaryEmail?.href ? (
+          <a className="primary-action" href={primaryEmail.href}>
+            Contact Aleksandar
+          </a>
+        ) : null}
+      </section>
+    </div>
   );
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -332,3 +332,198 @@ h1 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+.portfolio-page {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  max-width: 1120px;
+  width: min(100%, 1120px);
+}
+
+.portfolio-hero,
+.portfolio-section {
+  backdrop-filter: blur(16px);
+  background: rgba(15, 23, 42, 0.74);
+  border: 1px solid rgba(226, 232, 240, 0.2);
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 80px rgba(2, 6, 23, 0.45);
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.portfolio-hero {
+  align-items: stretch;
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+}
+
+.hero-copy {
+  align-content: center;
+  display: grid;
+  justify-items: start;
+  text-align: left;
+}
+
+.hero-copy .intro {
+  margin-left: 0;
+}
+
+.hero-subtitle {
+  color: #bfdbfe;
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  font-weight: 800;
+  margin: -0.75rem 0 1rem;
+}
+
+.bilingual-line {
+  color: #fef3c7 !important;
+  font-weight: 800;
+  margin-top: 0.5rem;
+}
+
+.hero-actions {
+  justify-content: flex-start;
+}
+
+.hero-highlight {
+  background:
+    linear-gradient(145deg, rgba(96, 165, 250, 0.18), rgba(15, 23, 42, 0.6)),
+    rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(147, 197, 253, 0.26);
+  border-radius: 1.25rem;
+  display: grid;
+  gap: 0.7rem;
+  padding: clamp(1rem, 3vw, 1.5rem);
+}
+
+.hero-highlight h2,
+.section-heading h2,
+.contact-cta h2,
+.feature-card h3,
+.skill-preview-grid h3 {
+  color: #ffffff;
+  margin: 0 0 0.65rem;
+}
+
+.hero-highlight p,
+.section-heading p,
+.contact-cta p {
+  color: #dbeafe;
+  margin: 0;
+}
+
+.section-heading {
+  margin: 0 auto 1.5rem;
+  max-width: 760px;
+  text-align: center;
+}
+
+.feature-grid,
+.skill-preview-grid,
+.narrative-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.feature-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.skill-preview-grid,
+.narrative-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.feature-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.feature-card .text-action {
+  align-self: flex-start;
+  margin-top: auto;
+}
+
+.inline-action {
+  display: table;
+  margin: 1.5rem auto 0;
+}
+
+.bio-preview,
+.contact-cta {
+  text-align: center;
+}
+
+.contact-cta {
+  display: grid;
+  justify-items: center;
+}
+
+.contact-cta .primary-action {
+  margin-top: 1.25rem;
+}
+
+.about-page .page-card,
+.about-hero {
+  max-width: none;
+  width: 100%;
+}
+
+.about-narrative {
+  display: grid;
+  gap: 1rem;
+}
+
+.narrative-lead {
+  text-align: left;
+}
+
+.narrative-lead .eyebrow {
+  margin-bottom: 0.75rem;
+}
+
+.compact-skill-list p {
+  margin-bottom: 0;
+}
+
+@media (max-width: 860px) {
+  .app-shell {
+    place-items: start center;
+  }
+
+  .portfolio-hero,
+  .feature-grid,
+  .skill-preview-grid,
+  .narrative-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-copy,
+  .hero-actions {
+    justify-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .hero-copy .intro {
+    margin-left: auto;
+  }
+}
+
+@media (max-width: 560px) {
+  .app-shell {
+    padding: 9rem 1rem 2rem;
+  }
+
+  .portfolio-hero,
+  .portfolio-section,
+  .page-card {
+    border-radius: 1.1rem;
+  }
+
+  .primary-action,
+  .secondary-action {
+    text-align: center;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a professional, responsive Home and About experience using the new design system and typed local data, with clear bilingual branding elements. 
- Move page content into reusable React components and typed data so content is maintainable and ready for further iteration.

### Description
- Added reusable portfolio components: `src/components/portfolio/Hero.tsx`, `FeaturedProjects.tsx`, `SkillsPreview.tsx`, and `AboutNarrative.tsx` to structure the Home and About content. 
- Reworked pages to consume the new components: `src/pages/HomePage.tsx` and `src/pages/AboutPage.tsx` now render hero, short bio, featured projects, skills preview, contact CTA, and a narrative-driven About section. 
- Expanded typed data to support the pages: updated `src/data/biography.ts`, `src/data/projects.ts`, and `src/data/skills.ts` with bilingual lines, short bio, `featuredProjects` and `skillPreviewGroups` helpers, and clearer professional copy. 
- Added responsive section styles and layout rules in `src/styles/globals.css` for two-column desktop sections and stacked mobile layouts to avoid layout shift.

### Testing
- `git diff --check` passed with no whitespace errors. 
- `npm run typecheck` failed due to the environment missing `react-router-dom` types (typecheck blocked). 
- `npm run lint` failed due to missing `@eslint/js` in the environment (lint blocked). 
- `npm install` could not complete in this environment (registry `403 Forbidden` for `@eslint/js`), which prevented full dependency restore and caused `npm run build` to fail at typecheck.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a280047a10883309ae42d7db37bf0da)