### PR TITLE
Add projects showcase and Algorithm of the Day case study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.local
+.DS_Store

--- a/src/components/portfolio/ProjectCard.tsx
+++ b/src/components/portfolio/ProjectCard.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router-dom';
+import type { Project } from '../../types/project';
+import { getProjectDetailPath } from '../../utils/routes';
+import ProjectLinks from './ProjectLinks';
+
+type ProjectCardProps = {
+  project: Project;
+};
+
+function ProjectCard({ project }: ProjectCardProps) {
+  return (
+    <article className={`info-panel project-card${project.featured ? ' featured-card' : ''}`}>
+      <div className="project-card-header">
+        <p className="status-label">{project.status}</p>
+        {project.featured ? <span className="featured-pill">Featured</span> : null}
+      </div>
+      <h2>{project.title}</h2>
+      {project.subtitle ? <p className="project-subtitle">{project.subtitle}</p> : null}
+      <p>{project.summary}</p>
+
+      <div className="project-meta-grid" aria-label={`${project.title} metadata`}>
+        <div>
+          <strong>Status</strong>
+          <span>{project.status}</span>
+        </div>
+        <div>
+          <strong>Technologies</strong>
+          <span>{project.technologies.slice(0, 3).join(' · ')}</span>
+        </div>
+      </div>
+
+      <div className="tag-list" aria-label={`${project.title} technologies`}>
+        {project.technologies.map((technology) => (
+          <span key={technology}>{technology}</span>
+        ))}
+      </div>
+
+      <div className="project-card-actions">
+        <Link className="text-action" to={getProjectDetailPath(project.id)}>
+          {project.placeholder ? 'Preview concept' : 'View case study'}
+        </Link>
+        <ProjectLinks links={project.links} />
+      </div>
+    </article>
+  );
+}
+
+export default ProjectCard;

--- a/src/components/portfolio/ProjectFilters.tsx
+++ b/src/components/portfolio/ProjectFilters.tsx
@@ -1,0 +1,42 @@
+import type { ProjectStatus } from '../../types/project';
+
+export type ProjectFilter = 'all' | ProjectStatus;
+
+type ProjectFiltersProps = {
+  activeFilter: ProjectFilter;
+  filters: readonly ProjectFilter[];
+  onFilterChange: (filter: ProjectFilter) => void;
+};
+
+const filterLabels: Record<ProjectFilter, string> = {
+  active: 'Active',
+  all: 'All',
+  archived: 'Archived',
+  concept: 'Concept',
+  featured: 'Featured',
+  'in-progress': 'In progress',
+  planned: 'Planned',
+};
+
+function ProjectFilters({ activeFilter, filters, onFilterChange }: ProjectFiltersProps) {
+  if (filters.length <= 2) {
+    return null;
+  }
+
+  return (
+    <div className="project-filters" aria-label="Filter projects by status">
+      {filters.map((filter) => (
+        <button
+          aria-pressed={activeFilter === filter}
+          key={filter}
+          onClick={() => onFilterChange(filter)}
+          type="button"
+        >
+          {filterLabels[filter]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default ProjectFilters;

--- a/src/components/portfolio/ProjectHero.tsx
+++ b/src/components/portfolio/ProjectHero.tsx
@@ -1,0 +1,39 @@
+import type { Project } from '../../types/project';
+import ProjectLinks from './ProjectLinks';
+
+type ProjectHeroProps = {
+  project: Project;
+};
+
+function ProjectHero({ project }: ProjectHeroProps) {
+  return (
+    <header className="project-hero">
+      <div>
+        <p className="eyebrow">Project case study</p>
+        <h1 id="page-title">{project.title}</h1>
+        {project.subtitle ? <p className="hero-subtitle">{project.subtitle}</p> : null}
+        <p className="intro">{project.description}</p>
+        <ProjectLinks links={project.links} />
+      </div>
+      <aside className="project-fact-card" aria-label="Project facts">
+        <p className="status-label">{project.featured ? 'Featured project' : 'Project'}</p>
+        <dl>
+          <div>
+            <dt>Status</dt>
+            <dd>{project.status}</dd>
+          </div>
+          <div>
+            <dt>Technologies</dt>
+            <dd>{project.technologies.join(', ')}</dd>
+          </div>
+          <div>
+            <dt>Focus</dt>
+            <dd>{project.tags.join(', ')}</dd>
+          </div>
+        </dl>
+      </aside>
+    </header>
+  );
+}
+
+export default ProjectHero;

--- a/src/components/portfolio/ProjectHighlights.tsx
+++ b/src/components/portfolio/ProjectHighlights.tsx
@@ -1,0 +1,25 @@
+import type { Project } from '../../types/project';
+
+type ProjectHighlightsProps = {
+  project: Project;
+};
+
+function ProjectHighlights({ project }: ProjectHighlightsProps) {
+  return (
+    <article className="info-panel project-highlights">
+      <h2>Highlights</h2>
+      <ul>
+        {project.highlights.map((highlight) => (
+          <li key={highlight}>{highlight}</li>
+        ))}
+      </ul>
+      <div className="tag-list" aria-label={`${project.title} tags`}>
+        {project.tags.map((tag) => (
+          <span key={tag}>{tag}</span>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export default ProjectHighlights;

--- a/src/components/portfolio/ProjectLinks.tsx
+++ b/src/components/portfolio/ProjectLinks.tsx
@@ -1,0 +1,34 @@
+import type { ProjectLink } from '../../types/project';
+
+type ProjectLinksProps = {
+  links: readonly ProjectLink[];
+};
+
+const linkKindLabels: Record<ProjectLink['kind'], string> = {
+  archive: 'Archive',
+  demo: 'Demo',
+  notebook: 'Notebook',
+  repository: 'Repository',
+  resource: 'Resource',
+};
+
+function ProjectLinks({ links }: ProjectLinksProps) {
+  const publicLinks = links.filter((link) => link.isPublic);
+
+  if (publicLinks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="project-links" aria-label="Project links">
+      {publicLinks.map((link) => (
+        <a key={link.url} href={link.url} rel="noreferrer" target="_blank">
+          <span>{link.label}</span>
+          <small>{linkKindLabels[link.kind]} · Opens in a new tab</small>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export default ProjectLinks;

--- a/src/data/algorithmOfTheDay.ts
+++ b/src/data/algorithmOfTheDay.ts
@@ -4,17 +4,18 @@ import type { Project } from '../types/project';
 export const algorithmOfTheDayProject: Project = {
   id: 'algorithm-of-the-day',
   title: 'Алгоритъмът на деня | Algorithm of the Day',
-  subtitle: 'A ritual media experiment where people and algorithms learn together.',
+  subtitle: 'A concept-stage media ritual where people and algorithms learn together.',
   summary:
     'An educational web page, digital business card, and creative learning prototype created by Aleksandar Kitipov with AI collaborators.',
   description:
-    'Algorithm of the Day turns current facts, news, and ideas into concise poetic rituals that combine commentary, metaphor, music, and a question for the community.',
-  status: 'featured',
+    'Algorithm of the Day is an in-progress case study for transforming current facts, news, and ideas into concise poetic rituals that combine commentary, metaphor, music, and a question for the community.',
+  status: 'in-progress',
   featured: true,
   tags: ['AI collaboration', 'Education', 'Media ritual', 'Community', 'Prototype'],
+  technologies: ['HTML', 'Google Colab', 'Markdown', 'AI-assisted writing'],
   highlights: [
-    'Frames Aleksandar as the conductor and architect of the project vision.',
-    'Combines facts, metaphors, rituals, music, and community prompts into an episode format.',
+    'Frames Aleksandar as the conductor and architect of the project vision without presenting the concept as a finished product.',
+    'Combines facts, metaphors, rituals, music, and community prompts into a repeatable episode format.',
     'Preserves the educational spirit of the original Notepad++ static website while moving toward typed React content.',
   ],
   links: [
@@ -32,6 +33,23 @@ export const algorithmOfTheDayProject: Project = {
     },
   ],
 };
+
+export const algorithmOfTheDayCaseStudy = {
+  overview:
+    'The project explores a small daily format: choose a signal from the world, translate it through an accessible metaphor, and invite people to respond. It is intentionally labeled in progress because the public artifact is still evolving from static notes into a polished publishing workflow.',
+  role:
+    'Aleksandar owns the concept, editorial direction, learning goals, and public presentation. AI tools support drafting, structuring, and iteration, but the portfolio presents the work as a human-led creative learning system.',
+  audience:
+    'Curious learners, friends, collaborators, and community members who enjoy bilingual education, reflective technology, and lightweight daily rituals.',
+  currentState:
+    'The repository and Colab notebook document the idea and experimentation path. The next milestone is turning the format into a repeatable archive with scripts, audio, journal entries, and community prompts.',
+  nextSteps: [
+    'Publish a small set of sample episodes before claiming a complete season.',
+    'Create a consistent Markdown template for scripts and notes.',
+    'Use the Colab notebook as a transparent workspace for experiments and generation support.',
+    'Collect community responses carefully before expanding the format.',
+  ],
+} as const;
 
 export const episodeFormat: readonly EpisodeFormatStep[] = [
   {

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -13,6 +13,7 @@ export const projects: readonly Project[] = [
       'Portfolio Foundation introduces typed local data, route-based pages, responsive cards, and safe public contact defaults for the next publishing iterations.',
     status: 'active',
     tags: ['React', 'TypeScript', 'Vite', 'Portfolio'],
+    technologies: ['React', 'TypeScript', 'Vite', 'CSS'],
     highlights: [
       'Migrates static legacy content into reusable modules.',
       'Separates private contact information from rendered public channels.',
@@ -37,6 +38,7 @@ export const projects: readonly Project[] = [
       'The archive keeps the original learning material available while the React portfolio extracts durable content into typed project, biography, and skill data.',
     status: 'archived',
     tags: ['HTML', 'Learning archive', 'Migration', 'Documentation'],
+    technologies: ['HTML', 'CSS', 'Static assets'],
     highlights: [
       'Documents the transition from hand-authored static pages to reusable React views.',
       'Preserves screenshots and legacy routes for context without exposing private contact details.',
@@ -50,6 +52,25 @@ export const projects: readonly Project[] = [
         isPublic: true,
       },
     ],
+  },
+  {
+    id: 'bilingual-learning-notes',
+    title: 'Bilingual Learning Notes',
+    subtitle: 'A planned space for Bulgarian-English study notes and reflections.',
+    summary:
+      'A concept placeholder for future writing that will connect portfolio updates with language learning and technical practice.',
+    description:
+      'Bilingual Learning Notes is a planned portfolio section, not a completed product. It is included to show the roadmap while keeping project maturity transparent.',
+    status: 'concept',
+    tags: ['Writing', 'Bulgarian', 'English', 'Learning'],
+    technologies: ['Markdown', 'React', 'Content modeling'],
+    highlights: [
+      'Reserved as a transparent placeholder for future project work.',
+      'Will focus on bilingual explanations rather than production software claims.',
+      'Can reuse the same typed data structure as mature case studies when content is ready.',
+    ],
+    links: [],
+    placeholder: true,
   },
 ];
 

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -1,4 +1,11 @@
 import { Link, useParams } from 'react-router-dom';
+import ProjectHero from '../components/portfolio/ProjectHero';
+import ProjectHighlights from '../components/portfolio/ProjectHighlights';
+import {
+  algorithmOfTheDayCaseStudy,
+  episodeFormat,
+  projectArchiveStructure,
+} from '../data/algorithmOfTheDay';
 import { projects } from '../data/projects';
 import { routes } from '../utils/routes';
 
@@ -21,41 +28,82 @@ function ProjectDetailPage() {
     );
   }
 
-  const publicLinks = project.links.filter((link) => link.isPublic);
+  const isAlgorithmOfTheDay = project.id === 'algorithm-of-the-day';
 
   return (
-    <section className="page-card" aria-labelledby="page-title">
-      <p className="eyebrow">Project detail</p>
-      <h1 id="page-title">{project.title}</h1>
-      <p className="intro">{project.description}</p>
+    <section className="page-card project-detail-page" aria-labelledby="page-title">
+      <ProjectHero project={project} />
 
       <div className="section-stack">
-        <article className="info-panel">
-          <h2>Highlights</h2>
-          <ul>
-            {project.highlights.map((highlight) => (
-              <li key={highlight}>{highlight}</li>
-            ))}
-          </ul>
-          <div className="tag-list" aria-label={`${project.title} tags`}>
-            {project.tags.map((tag) => (
-              <span key={tag}>{tag}</span>
-            ))}
-          </div>
-        </article>
+        <ProjectHighlights project={project} />
 
-        {publicLinks.length > 0 ? (
+        {isAlgorithmOfTheDay ? (
+          <>
+            <article className="info-panel case-study-panel">
+              <h2>Case study</h2>
+              <div className="case-study-grid">
+                <section>
+                  <h3>Overview</h3>
+                  <p>{algorithmOfTheDayCaseStudy.overview}</p>
+                </section>
+                <section>
+                  <h3>Role</h3>
+                  <p>{algorithmOfTheDayCaseStudy.role}</p>
+                </section>
+                <section>
+                  <h3>Audience</h3>
+                  <p>{algorithmOfTheDayCaseStudy.audience}</p>
+                </section>
+                <section>
+                  <h3>Current state</h3>
+                  <p>{algorithmOfTheDayCaseStudy.currentState}</p>
+                </section>
+              </div>
+            </article>
+
+            <article className="info-panel">
+              <h2>Episode format</h2>
+              <ol className="episode-steps">
+                {episodeFormat.map((step) => (
+                  <li key={step.title}>
+                    <strong>{step.title}</strong>
+                    <span>{step.description}</span>
+                  </li>
+                ))}
+              </ol>
+            </article>
+
+            <article className="info-panel case-study-grid two-column-grid">
+              <section>
+                <h2>Planned archive structure</h2>
+                <ul>
+                  {projectArchiveStructure.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </section>
+              <section>
+                <h2>Next steps</h2>
+                <ul>
+                  {algorithmOfTheDayCaseStudy.nextSteps.map((step) => (
+                    <li key={step}>{step}</li>
+                  ))}
+                </ul>
+              </section>
+            </article>
+          </>
+        ) : (
           <article className="info-panel">
-            <h2>Public links</h2>
-            <div className="content-list compact-list">
-              {publicLinks.map((link) => (
-                <a key={link.url} href={link.url} rel="noreferrer" target="_blank">
-                  {link.label}
-                </a>
-              ))}
-            </div>
+            <h2>Project notes</h2>
+            <p>{project.description}</p>
+            {project.placeholder ? (
+              <p>
+                This card is intentionally labeled as a concept so visitors can separate
+                future roadmap ideas from shipped portfolio work.
+              </p>
+            ) : null}
           </article>
-        ) : null}
+        )}
       </div>
 
       <Link className="text-action" to={routes.projects}>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,32 +1,37 @@
-import { Link } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import ProjectCard from '../components/portfolio/ProjectCard';
+import ProjectFilters, { type ProjectFilter } from '../components/portfolio/ProjectFilters';
 import { projects } from '../data/projects';
-import { getProjectDetailPath } from '../utils/routes';
 
 function ProjectsPage() {
+  const availableFilters = useMemo<readonly ProjectFilter[]>(() => {
+    const statuses = Array.from(new Set(projects.map((project) => project.status)));
+    return ['all', ...statuses];
+  }, []);
+  const [activeFilter, setActiveFilter] = useState<ProjectFilter>('all');
+
+  const filteredProjects = projects.filter(
+    (project) => activeFilter === 'all' || project.status === activeFilter,
+  );
+
   return (
-    <section className="page-card" aria-labelledby="page-title">
+    <section className="page-card projects-page" aria-labelledby="page-title">
       <p className="eyebrow">Projects</p>
       <h1 id="page-title">Portfolio Projects</h1>
       <p className="intro">
-        Featured applications, experiments, and algorithm practice are now backed by
-        reusable typed project data.
+        Featured applications, experiments, and transparent future placeholders are backed
+        by reusable typed project data.
       </p>
-      <div className="card-grid" aria-label="Project links">
-        {projects.map((project) => (
-          <article className="info-panel" key={project.id}>
-            <p className="status-label">{project.status}</p>
-            <h2>{project.title}</h2>
-            {project.subtitle ? <p>{project.subtitle}</p> : null}
-            <p>{project.summary}</p>
-            <div className="tag-list" aria-label={`${project.title} tags`}>
-              {project.tags.map((tag) => (
-                <span key={tag}>{tag}</span>
-              ))}
-            </div>
-            <Link className="text-action" to={getProjectDetailPath(project.id)}>
-              View project
-            </Link>
-          </article>
+
+      <ProjectFilters
+        activeFilter={activeFilter}
+        filters={availableFilters}
+        onFilterChange={setActiveFilter}
+      />
+
+      <div className="card-grid project-grid" aria-label="Project links">
+        {filteredProjects.map((project) => (
+          <ProjectCard key={project.id} project={project} />
         ))}
       </div>
     </section>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -527,3 +527,288 @@ h1 {
     width: 100%;
   }
 }
+
+.projects-page,
+.project-detail-page {
+  max-width: 1080px;
+  width: min(100%, 1080px);
+}
+
+.project-grid {
+  align-items: stretch;
+}
+
+.project-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.project-card-header,
+.project-card-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.project-card h2 {
+  color: #ffffff;
+  margin: 0;
+}
+
+.project-subtitle {
+  color: #bfdbfe !important;
+  font-weight: 800;
+}
+
+.featured-card {
+  background:
+    linear-gradient(145deg, rgba(96, 165, 250, 0.18), rgba(15, 23, 42, 0.54)),
+    rgba(15, 23, 42, 0.6);
+  border-color: rgba(147, 197, 253, 0.34);
+}
+
+.featured-pill {
+  background: rgba(250, 204, 21, 0.16);
+  border: 1px solid rgba(253, 224, 71, 0.36);
+  border-radius: 999px;
+  color: #fef3c7;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  padding: 0.25rem 0.55rem;
+  text-transform: uppercase;
+}
+
+.project-meta-grid {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.project-meta-grid div {
+  background: rgba(2, 6, 23, 0.28);
+  border: 1px solid rgba(226, 232, 240, 0.14);
+  border-radius: 0.85rem;
+  padding: 0.75rem;
+}
+
+.project-meta-grid strong,
+.project-meta-grid span {
+  display: block;
+}
+
+.project-meta-grid strong {
+  color: #ffffff;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
+.project-meta-grid span {
+  color: #dbeafe;
+  font-size: 0.9rem;
+}
+
+.project-card .text-action {
+  margin-top: auto;
+}
+
+.project-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
+.project-links a {
+  border: 1px solid rgba(147, 197, 253, 0.28);
+  border-radius: 0.9rem;
+  color: #dbeafe;
+  display: grid;
+  gap: 0.15rem;
+  min-width: 12rem;
+  padding: 0.75rem 0.9rem;
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.project-links a:hover,
+.project-links a:focus-visible {
+  background: rgba(96, 165, 250, 0.16);
+  transform: translateY(-1px);
+}
+
+.project-links span {
+  font-weight: 900;
+}
+
+.project-links small {
+  color: #bfdbfe;
+  font-weight: 600;
+}
+
+.project-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  justify-content: center;
+  margin: 1.5rem auto 0;
+}
+
+.project-filters button {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(226, 232, 240, 0.24);
+  border-radius: 999px;
+  color: #dbeafe;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 800;
+  padding: 0.55rem 0.9rem;
+}
+
+.project-filters button:hover,
+.project-filters button:focus-visible,
+.project-filters button[aria-pressed='true'] {
+  background: rgba(96, 165, 250, 0.22);
+  border-color: rgba(191, 219, 254, 0.44);
+}
+
+.project-hero {
+  display: grid;
+  gap: clamp(1rem, 3vw, 2rem);
+  grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+  text-align: left;
+}
+
+.project-hero .intro {
+  margin-left: 0;
+}
+
+.project-fact-card {
+  background: rgba(2, 6, 23, 0.3);
+  border: 1px solid rgba(147, 197, 253, 0.26);
+  border-radius: 1.1rem;
+  padding: 1.2rem;
+}
+
+.project-fact-card dl,
+.project-fact-card dd {
+  margin: 0;
+}
+
+.project-fact-card dl {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.project-fact-card dt {
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.project-fact-card dd {
+  color: #dbeafe;
+  margin-top: 0.2rem;
+}
+
+.project-highlights h2,
+.case-study-panel h2 {
+  color: #ffffff;
+}
+
+.case-study-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.case-study-grid h3,
+.case-study-grid h2 {
+  color: #ffffff;
+  font-size: 1rem;
+  margin: 0 0 0.45rem;
+}
+
+.case-study-grid p {
+  margin-bottom: 0;
+}
+
+.episode-steps {
+  display: grid;
+  gap: 0.85rem;
+  list-style: none;
+  padding-left: 0 !important;
+}
+
+.episode-steps li {
+  background: rgba(2, 6, 23, 0.24);
+  border: 1px solid rgba(226, 232, 240, 0.14);
+  border-radius: 0.9rem;
+  counter-increment: episode-step;
+  padding: 0.85rem 0.85rem 0.85rem 3rem;
+  position: relative;
+}
+
+.episode-steps li::before {
+  align-items: center;
+  background: rgba(96, 165, 250, 0.2);
+  border-radius: 999px;
+  color: #ffffff;
+  content: counter(episode-step);
+  display: grid;
+  font-weight: 900;
+  height: 1.8rem;
+  left: 0.75rem;
+  place-items: center;
+  position: absolute;
+  top: 0.85rem;
+  width: 1.8rem;
+}
+
+.episode-steps strong,
+.episode-steps span {
+  display: block;
+}
+
+.episode-steps strong {
+  color: #ffffff;
+}
+
+.episode-steps span {
+  color: #dbeafe;
+  margin-top: 0.15rem;
+}
+
+@media (max-width: 860px) {
+  .project-hero,
+  .case-study-grid,
+  .two-column-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .project-meta-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .project-card-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .project-links,
+  .project-links a {
+    width: 100%;
+  }
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,4 +1,4 @@
-export type ProjectStatus = 'featured' | 'active' | 'archived' | 'planned';
+export type ProjectStatus = 'featured' | 'active' | 'in-progress' | 'concept' | 'archived' | 'planned';
 
 export type ProjectLink = {
   label: string;
@@ -15,7 +15,9 @@ export type Project = {
   description: string;
   status: ProjectStatus;
   tags: readonly string[];
+  technologies: readonly string[];
   highlights: readonly string[];
   links: readonly ProjectLink[];
   featured?: boolean;
+  placeholder?: boolean;
 };


### PR DESCRIPTION
### Motivation
- Provide a reusable project showcase for the portfolio with clearer maturity signals and public links, and publish a transparent in-progress case study for Algorithm of the Day.
- Surface project metadata (status, technologies, tags) so visitors can quickly understand work and roadmap items.
- Offer a filter UI that can be enabled as more projects are added while keeping concept/placeholder items clearly labeled.

### Description
- Added typed project model fields and placeholders by expanding `src/types/project.ts` and `src/data/projects.ts` to include `technologies`, `placeholder`, and new statuses such as `in-progress` and `concept`.
- Implemented reusable components `ProjectCard`, `ProjectFilters`, `ProjectLinks`, `ProjectHero`, and `ProjectHighlights` under `src/components/portfolio/` to render project cards, filter controls, public links (opened with `target="_blank" rel="noreferrer"`), hero metadata, and highlights.
- Created a detailed Algorithm of the Day case study in `src/data/algorithmOfTheDay.ts` and updated `src/pages/ProjectDetailPage.tsx` and `src/pages/ProjectsPage.tsx` to render filters, project cards, and the algorithm case-study sections (overview, role, audience, episode format, archive structure, next steps).
- Added responsive project-specific styles to `src/styles/globals.css` and a `.gitignore` to exclude local deps/build artifacts.

### Testing
- Ran `npm run typecheck`, which failed due to missing local `react-router-dom` types and unavailable registry access preventing dependency installation (TypeScript reported module not found errors).
- Attempted `npm install` and `npm install react-router-dom@latest`, both blocked by the npm registry with `403 Forbidden` errors, preventing a full install and runtime verification.
- Ran `npm run build`, which failed at the `typecheck` step for the same missing dependency issue.
- Ran `npm run lint`, which failed because `@eslint/js` could not be installed due to registry access restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2803defaa48330999838501d712692)