### PR TITLE
Add skills matrix, curated links, and safe contact page

### DIFF
--- a/src/components/portfolio/ContactCard.tsx
+++ b/src/components/portfolio/ContactCard.tsx
@@ -1,0 +1,26 @@
+import type { ContactChannel } from '../../types/contact';
+
+type ContactCardProps = {
+  channel: ContactChannel;
+};
+
+function ContactCard({ channel }: ContactCardProps) {
+  return (
+    <article
+      className="info-panel contact-card"
+      aria-labelledby={`contact-${channel.id}`}
+    >
+      <h2 id={`contact-${channel.id}`}>{channel.label}</h2>
+      {channel.href ? (
+        <a aria-label={channel.accessibleLabel} href={channel.href}>
+          {channel.value}
+        </a>
+      ) : (
+        <p>{channel.value}</p>
+      )}
+      {channel.note ? <p className="page-note">{channel.note}</p> : null}
+    </article>
+  );
+}
+
+export default ContactCard;

--- a/src/components/portfolio/ResourceList.tsx
+++ b/src/components/portfolio/ResourceList.tsx
@@ -1,0 +1,43 @@
+import type { SocialLink } from '../../types/contact';
+
+type ResourceListProps = {
+  links: readonly SocialLink[];
+};
+
+const resourceKindLabels: Record<SocialLink['kind'], string> = {
+  github: 'GitHub',
+  facebook: 'Social profile',
+  learning: 'Learning resource',
+  tool: 'Tool',
+  legacy: 'Legacy archive',
+  python: 'Python',
+  ai: 'AI collaboration',
+  other: 'Resource',
+};
+
+function ResourceList({ links }: ResourceListProps) {
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="resource-list" aria-label="Curated external resources">
+      {links.map((link) => (
+        <a
+          aria-label={`${link.label}: ${link.description ?? resourceKindLabels[link.kind]} (opens in a new tab)`}
+          className="resource-card"
+          key={link.label}
+          href={link.url}
+          rel="noreferrer"
+          target="_blank"
+        >
+          <span className="status-label">{resourceKindLabels[link.kind]}</span>
+          <strong>{link.label}</strong>
+          {link.description ? <small>{link.description}</small> : null}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export default ResourceList;

--- a/src/components/portfolio/SkillGroup.tsx
+++ b/src/components/portfolio/SkillGroup.tsx
@@ -1,0 +1,31 @@
+import type { SkillGroup as SkillGroupData } from '../../types/skill';
+
+type SkillGroupProps = {
+  group: SkillGroupData;
+};
+
+function SkillGroup({ group }: SkillGroupProps) {
+  return (
+    <article
+      className="info-panel skill-group-card"
+      aria-labelledby={`skill-${group.id}`}
+    >
+      <div className="skill-group-heading">
+        <p className="status-label">{group.categoryLabel}</p>
+        <h2 id={`skill-${group.id}`}>{group.title}</h2>
+      </div>
+      <p>{group.description}</p>
+      <div className="skill-list" aria-label={`${group.title} skills`}>
+        {group.skills.map((skill) => (
+          <div key={skill.name}>
+            <strong>{skill.name}</strong>
+            <span>{skill.level}</span>
+            <p>{skill.summary}</p>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export default SkillGroup;

--- a/src/components/portfolio/SocialLinks.tsx
+++ b/src/components/portfolio/SocialLinks.tsx
@@ -1,0 +1,33 @@
+import type { SocialLink } from '../../types/contact';
+
+type SocialLinksProps = {
+  links: readonly SocialLink[];
+};
+
+function SocialLinks({ links }: SocialLinksProps) {
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="content-list social-link-list"
+      aria-label="Public profiles and project links"
+    >
+      {links.map((link) => (
+        <a
+          aria-label={`${link.label}: ${link.description ?? 'external resource'} (opens in a new tab)`}
+          key={link.label}
+          href={link.url}
+          rel="noreferrer"
+          target="_blank"
+        >
+          <span>{link.label}</span>
+          {link.description ? <small>{link.description}</small> : null}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export default SocialLinks;

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -2,93 +2,159 @@ import type { SkillGroup } from '../types/skill';
 
 export const skillGroups: readonly SkillGroup[] = [
   {
-    title: 'Languages and foundations',
-    description: 'Core languages and concepts used across learning prototypes.',
+    id: 'frontend',
+    title: 'Frontend',
+    categoryLabel: 'Frontend craft',
+    description:
+      'Accessible page structure, responsive presentation, and component-based portfolio delivery.',
     skills: [
       {
-        name: 'HTML and semantic structure',
-        category: 'language',
+        name: 'Semantic HTML',
+        category: 'frontend',
         level: 'building',
         summary:
-          'Used in the original static pages and carried forward into accessible React markup.',
+          'Uses landmark sections, labelled headings, and meaningful link text across portfolio pages.',
       },
       {
-        name: 'CSS and responsive presentation',
+        name: 'CSS layout and responsive cards',
         category: 'frontend',
         level: 'practicing',
         summary:
-          'Supports the portfolio background, cards, lists, and readable content sections.',
+          'Shapes the background, panels, cards, lists, mobile breakpoints, and readable content hierarchy.',
       },
-      {
-        name: 'JavaScript and TypeScript',
-        category: 'language',
-        level: 'practicing',
-        summary:
-          'Turns page shells into typed reusable data, route-aware components, and maintainable content structures.',
-      },
-      {
-        name: 'Python learning environment',
-        category: 'language',
-        level: 'learning',
-        summary:
-          'Explored through Google Colab and algorithm-oriented learning resources.',
-      },
-    ],
-  },
-  {
-    title: 'Tools and workflow',
-    description: 'Editors, platforms, and habits represented in the legacy content.',
-    skills: [
       {
         name: 'React and Vite',
         category: 'frontend',
         level: 'building',
-        summary: 'Power the modern routed portfolio application and fast local iteration.',
-      },
-      {
-        name: 'GitHub project publishing',
-        category: 'tooling',
-        level: 'practicing',
-        summary: 'Hosts code, project links, and the GitHub Pages portfolio workflow.',
-      },
-      {
-        name: 'Notepad++ and browser prototyping',
-        category: 'tooling',
-        level: 'building',
-        summary: 'Part of the original website origin story and educational workflow.',
-      },
-      {
-        name: 'AI-assisted collaboration',
-        category: 'collaboration',
-        level: 'building',
         summary:
-          'Uses Copilot and Gemini as creative partners for text, code, data, and commentary while preserving human direction.',
+          'Powers routed pages, typed data rendering, reusable portfolio components, and fast local iteration.',
       },
     ],
   },
   {
-    title: 'Creative media practice',
-    description: 'Skills tied to the Algorithm of the Day format.',
+    id: 'programming',
+    title: 'Programming',
+    categoryLabel: 'Programming foundations',
+    description:
+      'Languages and algorithm-oriented learning practices used for project prototypes and notebooks.',
+    skills: [
+      {
+        name: 'JavaScript and TypeScript',
+        category: 'programming',
+        level: 'practicing',
+        summary:
+          'Turns static content into typed reusable data, route-aware components, and maintainable UI logic.',
+      },
+      {
+        name: 'Python learning environment',
+        category: 'programming',
+        level: 'learning',
+        summary:
+          'Explored through Google Colab notebooks and algorithm-centered learning resources.',
+      },
+      {
+        name: 'Algorithmic thinking',
+        category: 'programming',
+        level: 'learning',
+        summary:
+          'Connects everyday metaphors, facts, and rituals to concrete programming concepts.',
+      },
+    ],
+  },
+  {
+    id: 'tools',
+    title: 'Tools',
+    categoryLabel: 'Publishing workflow',
+    description:
+      'Editors, hosting platforms, and learning environments represented in the portfolio origin story.',
+    skills: [
+      {
+        name: 'GitHub project publishing',
+        category: 'tools',
+        level: 'practicing',
+        summary:
+          'Hosts code, repository links, and the GitHub Pages portfolio workflow.',
+      },
+      {
+        name: 'Google Colab',
+        category: 'tools',
+        level: 'learning',
+        summary: 'Provides a browser-based place to experiment with Python notebooks.',
+      },
+      {
+        name: 'Notepad++ and browser prototyping',
+        category: 'tools',
+        level: 'building',
+        summary: 'Part of the original website origin story and educational workflow.',
+      },
+    ],
+  },
+  {
+    id: 'ai-collaboration',
+    title: 'AI collaboration',
+    categoryLabel: 'Human-directed AI',
+    description:
+      'AI tools are framed as collaborators for exploration while preserving Aleksandar’s editorial direction.',
+    skills: [
+      {
+        name: 'Prompted code assistance',
+        category: 'ai-collaboration',
+        level: 'building',
+        summary:
+          'Uses AI assistants to generate, review, and refine portfolio code with human verification.',
+      },
+      {
+        name: 'Research and explanation support',
+        category: 'ai-collaboration',
+        level: 'practicing',
+        summary:
+          'Turns learning questions into structured summaries, examples, and next-step prompts.',
+      },
+    ],
+  },
+  {
+    id: 'creative-direction',
+    title: 'Creative direction',
+    categoryLabel: 'Algorithm of the Day',
+    description:
+      'Editorial structure for episodes, metaphors, and community-friendly learning moments.',
     skills: [
       {
         name: 'Episode design',
-        category: 'creative',
+        category: 'creative-direction',
         level: 'practicing',
         summary:
           'Shapes prologue, fact, metaphor, ritual, music, and community question segments.',
       },
       {
-        name: 'Community prompts',
-        category: 'creative',
-        level: 'learning',
-        summary: 'Turns listener participation into material for future episodes.',
-      },
-      {
         name: 'Bilingual content framing',
-        category: 'creative',
+        category: 'creative-direction',
         level: 'practicing',
         summary:
           'Blends Bulgarian project identity with concise English explanations for a wider audience.',
+      },
+    ],
+  },
+  {
+    id: 'communication',
+    title: 'Communication',
+    categoryLabel: 'Public presentation',
+    description:
+      'Clear, privacy-aware communication for readers, reviewers, and future collaborators.',
+    skills: [
+      {
+        name: 'Community prompts',
+        category: 'communication',
+        level: 'learning',
+        summary:
+          'Turns listener participation and questions into material for future episodes.',
+      },
+      {
+        name: 'Privacy-aware contact publishing',
+        category: 'communication',
+        level: 'building',
+        summary:
+          'Keeps street address and phone data private while publishing safe contact options.',
       },
     ],
   },

--- a/src/data/socialLinks.ts
+++ b/src/data/socialLinks.ts
@@ -1,15 +1,23 @@
 import type { ContactChannel, SocialLink } from '../types/contact';
 
+const publicEmail = 'aeksandar.kitipov@gmail.com';
+const safeMailto = `mailto:${publicEmail}?subject=${encodeURIComponent(
+  'Portfolio inquiry',
+)}&body=${encodeURIComponent('Hello Aleksandar,\n\n')}`;
+
 export const contactChannels: readonly ContactChannel[] = [
   {
+    id: 'preferred-email',
     label: 'Preferred public email',
-    value: 'aeksandar.kitipov@gmail.com',
-    href: 'mailto:aeksandar.kitipov@gmail.com',
+    value: publicEmail,
+    href: safeMailto,
+    accessibleLabel: `Send an email to Aleksandar Kitipov at ${publicEmail}`,
     kind: 'email',
     visibility: 'public',
-    note: 'Safe default from the legacy site; confirm this remains the preferred publishing email.',
+    note: 'Safe default from the legacy site; reviewer should confirm this remains the final public email.',
   },
   {
+    id: 'outlook-email',
     label: 'Outlook email',
     value: 'aeksandar.kitipov@outlook.com',
     kind: 'email',
@@ -17,6 +25,7 @@ export const contactChannels: readonly ContactChannel[] = [
     note: 'Legacy address retained in data for review but not rendered publicly.',
   },
   {
+    id: 'abv-email',
     label: 'ABV email',
     value: 'aleksandar.kitipov@abv.bg',
     kind: 'email',
@@ -24,6 +33,7 @@ export const contactChannels: readonly ContactChannel[] = [
     note: 'Legacy address retained in data for review but not rendered publicly.',
   },
   {
+    id: 'private-phone',
     label: 'Phone',
     value: 'Private phone number from legacy contacts',
     kind: 'phone',
@@ -31,18 +41,20 @@ export const contactChannels: readonly ContactChannel[] = [
     note: 'Do not render until Aleksandar confirms that a phone number should be public.',
   },
   {
-    label: 'Address',
+    id: 'private-address',
+    label: 'Street address',
     value: 'Private street address from legacy contacts',
     kind: 'location',
     visibility: 'private',
-    note: 'Sensitive street address intentionally excluded from rendering.',
+    note: 'Full street address intentionally excluded from public pages.',
   },
   {
+    id: 'city-location',
     label: 'Location',
     value: 'Plovdiv, Bulgaria',
     kind: 'location',
     visibility: 'public',
-    note: 'City-level location only.',
+    note: 'City-level location only; no full street address is published.',
   },
 ];
 
@@ -67,33 +79,39 @@ export const socialLinks: readonly SocialLink[] = [
       'Cloud notebook connected to the Algorithm of the Day learning workflow.',
   },
   {
-    label: 'Facebook profile name',
-    url: 'https://www.facebook.com/',
-    kind: 'facebook',
-    isPublic: false,
-    description:
-      'Legacy content listed the name “Aleksandar Kitipov”; no profile URL is published until confirmed.',
-  },
-  {
-    label: 'Copilot Microsoft',
-    url: 'https://copilot.microsoft.com',
-    kind: 'tool',
-    isPublic: true,
-    description: 'AI assistant referenced as a collaborator in the legacy pages.',
-  },
-  {
     label: 'GitHub',
     url: 'https://github.com/',
-    kind: 'tool',
+    kind: 'github',
     isPublic: true,
-    description: 'Platform for code and projects.',
+    description: 'Platform for source control, portfolio code, and project publishing.',
+  },
+  {
+    label: 'Python.org',
+    url: 'https://www.python.org/',
+    kind: 'python',
+    isPublic: true,
+    description: 'Official Python language documentation and learning resource.',
   },
   {
     label: 'Google Colab',
     url: 'https://colab.research.google.com/',
     kind: 'tool',
     isPublic: true,
-    description: 'Cloud environment for Python learning.',
+    description: 'Browser-based notebook environment for Python experiments.',
+  },
+  {
+    label: 'Microsoft Copilot',
+    url: 'https://copilot.microsoft.com/',
+    kind: 'ai',
+    isPublic: true,
+    description: 'AI assistant referenced as a collaborator in the legacy pages.',
+  },
+  {
+    label: 'Google Gemini',
+    url: 'https://gemini.google.com/',
+    kind: 'ai',
+    isPublic: true,
+    description: 'AI assistant referenced for learning, writing, and ideation support.',
   },
   {
     label: 'Notepad++',
@@ -103,11 +121,12 @@ export const socialLinks: readonly SocialLink[] = [
     description: 'Editor used in the legacy site origin story.',
   },
   {
-    label: 'Python.org',
-    url: 'https://www.python.org/',
-    kind: 'tool',
-    isPublic: true,
-    description: 'Official Python learning resource.',
+    label: 'Facebook profile name',
+    url: 'https://www.facebook.com/',
+    kind: 'facebook',
+    isPublic: false,
+    description:
+      'Legacy content listed the name “Aleksandar Kitipov”; no profile URL is published until confirmed.',
   },
   {
     label: 'Legacy archive',

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,4 +1,6 @@
-import { publicContactChannels } from '../data/socialLinks';
+import ContactCard from '../components/portfolio/ContactCard';
+import SocialLinks from '../components/portfolio/SocialLinks';
+import { publicContactChannels, publicSocialLinks } from '../data/socialLinks';
 
 function ContactPage() {
   const primaryEmail = publicContactChannels.find(
@@ -6,33 +8,35 @@ function ContactPage() {
   );
 
   return (
-    <section className="page-card" aria-labelledby="page-title">
+    <section className="page-card contact-page" aria-labelledby="page-title">
       <p className="eyebrow">Contact</p>
       <h1 id="page-title">Contact Aleksandar</h1>
       <p className="intro">
-        Public contact details use safe defaults. Legacy phone numbers and street
-        address data are marked private and are not rendered here.
+        Public contact details use safe defaults. Full street address, phone number, and
+        unconfirmed profile URLs are marked private and are not rendered here.
       </p>
-      <div className="section-stack">
+      <div className="section-stack contact-grid" aria-label="Public contact options">
         {publicContactChannels.map((channel) => (
-          <article className="info-panel" key={`${channel.kind}-${channel.value}`}>
-            <h2>{channel.label}</h2>
-            {channel.href ? (
-              <a href={channel.href}>{channel.value}</a>
-            ) : (
-              <p>{channel.value}</p>
-            )}
-            {channel.note ? <p className="page-note">{channel.note}</p> : null}
-          </article>
+          <ContactCard channel={channel} key={channel.id} />
         ))}
       </div>
       {primaryEmail?.href ? (
         <div className="actions">
-          <a className="primary-action" href={primaryEmail.href}>
+          <a
+            aria-label={
+              primaryEmail.accessibleLabel ?? 'Send an email to Aleksandar Kitipov'
+            }
+            className="primary-action"
+            href={primaryEmail.href}
+          >
             Send email
           </a>
         </div>
       ) : null}
+      <div className="contact-resources" aria-labelledby="contact-links-title">
+        <h2 id="contact-links-title">Public project links</h2>
+        <SocialLinks links={publicSocialLinks.slice(0, 3)} />
+      </div>
     </section>
   );
 }

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -1,22 +1,17 @@
+import ResourceList from '../components/portfolio/ResourceList';
 import { publicSocialLinks } from '../data/socialLinks';
 
 function LinksPage() {
   return (
-    <section className="page-card" aria-labelledby="page-title">
+    <section className="page-card links-page" aria-labelledby="page-title">
       <p className="eyebrow">Links</p>
-      <h1 id="page-title">Useful Links</h1>
+      <h1 id="page-title">Curated Links</h1>
       <p className="intro">
-        External profiles, learning resources, legacy pages, and reference material are
-        rendered from public typed link data.
+        Public project links, learning notebooks, GitHub resources, Python references,
+        and AI collaboration tools are collected here. Unconfirmed social profiles stay
+        private until an official URL is available.
       </p>
-      <div className="content-list" aria-label="Public reference links">
-        {publicSocialLinks.map((link) => (
-          <a key={link.label} href={link.url} rel="noreferrer" target="_blank">
-            <span>{link.label}</span>
-            {link.description ? <small>{link.description}</small> : null}
-          </a>
-        ))}
-      </div>
+      <ResourceList links={publicSocialLinks} />
     </section>
   );
 }

--- a/src/pages/SkillsPage.tsx
+++ b/src/pages/SkillsPage.tsx
@@ -1,29 +1,18 @@
+import SkillGroup from '../components/portfolio/SkillGroup';
 import { skillGroups } from '../data/skills';
 
 function SkillsPage() {
   return (
-    <section className="page-card" aria-labelledby="page-title">
+    <section className="page-card skills-page" aria-labelledby="page-title">
       <p className="eyebrow">Skills</p>
-      <h1 id="page-title">Technical Skills</h1>
+      <h1 id="page-title">Skills Matrix</h1>
       <p className="intro">
-        Languages, tools, workflows, and creative practices extracted from the legacy
-        portfolio into typed data groups.
+        Frontend, programming, tools, AI collaboration, creative direction, and
+        communication skills are grouped into typed portfolio data.
       </p>
-      <div className="section-stack">
+      <div className="section-stack skill-matrix" aria-label="Grouped skills matrix">
         {skillGroups.map((group) => (
-          <article className="info-panel" key={group.title}>
-            <h2>{group.title}</h2>
-            <p>{group.description}</p>
-            <div className="skill-list">
-              {group.skills.map((skill) => (
-                <div key={skill.name}>
-                  <strong>{skill.name}</strong>
-                  <span>{skill.level}</span>
-                  <p>{skill.summary}</p>
-                </div>
-              ))}
-            </div>
-          </article>
+          <SkillGroup group={group} key={group.id} />
         ))}
       </div>
     </section>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -812,3 +812,91 @@ h1 {
     width: 100%;
   }
 }
+
+.skills-page,
+.links-page,
+.contact-page {
+  max-width: 1020px;
+  width: min(100%, 1020px);
+}
+
+.skill-matrix,
+.resource-list,
+.contact-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.skill-group-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skill-group-heading h2 {
+  margin-bottom: 0;
+}
+
+.resource-list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+  text-align: left;
+}
+
+.resource-card {
+  background: rgba(15, 23, 42, 0.46);
+  border: 1px solid rgba(226, 232, 240, 0.18);
+  border-radius: 1.1rem;
+  color: #dbeafe;
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem;
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.resource-card:hover,
+.resource-card:focus-visible {
+  background: rgba(96, 165, 250, 0.16);
+  transform: translateY(-1px);
+}
+
+.resource-card strong {
+  color: #ffffff;
+  font-size: 1.05rem;
+}
+
+.resource-card small,
+.contact-card .page-note {
+  color: #bfdbfe;
+  font-weight: 600;
+}
+
+.contact-card {
+  text-align: left;
+}
+
+.contact-resources {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.contact-resources h2 {
+  color: #ffffff;
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.social-link-list {
+  max-width: none;
+}
+
+@media (max-width: 860px) {
+  .skill-matrix,
+  .resource-list,
+  .contact-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -1,9 +1,11 @@
 export type ContactVisibility = 'public' | 'private';
 
 export type ContactChannel = {
+  id: string;
   label: string;
   value: string;
   href?: string;
+  accessibleLabel?: string;
   kind: 'email' | 'phone' | 'location' | 'social' | 'website' | 'messaging';
   visibility: ContactVisibility;
   note?: string;
@@ -12,7 +14,15 @@ export type ContactChannel = {
 export type SocialLink = {
   label: string;
   url: string;
-  kind: 'github' | 'facebook' | 'learning' | 'tool' | 'legacy' | 'other';
+  kind:
+    | 'github'
+    | 'facebook'
+    | 'learning'
+    | 'tool'
+    | 'legacy'
+    | 'python'
+    | 'ai'
+    | 'other';
   isPublic: boolean;
   description?: string;
 };

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -1,20 +1,24 @@
 export type SkillLevel = 'learning' | 'practicing' | 'building';
 
+export type SkillCategory =
+  | 'frontend'
+  | 'programming'
+  | 'tools'
+  | 'ai-collaboration'
+  | 'creative-direction'
+  | 'communication';
+
 export type Skill = {
   name: string;
-  category:
-    | 'language'
-    | 'frontend'
-    | 'tooling'
-    | 'workflow'
-    | 'collaboration'
-    | 'creative';
+  category: SkillCategory;
   level: SkillLevel;
   summary: string;
 };
 
 export type SkillGroup = {
+  id: SkillCategory;
   title: string;
+  categoryLabel: string;
   description: string;
   skills: readonly Skill[];
 };


### PR DESCRIPTION
### Motivation
- Provide typed, grouped portfolio pages for skills, curated external resources, and privacy-aware contact options. 
- Reflect legacy content while keeping sensitive contact details private and improving accessibility. 

### Description
- Added new reusable components: `src/components/portfolio/SkillGroup.tsx`, `SocialLinks.tsx`, `ContactCard.tsx`, and `ResourceList.tsx` and updated styles in `src/styles/globals.css` to support the new layouts. 
- Expanded and retyped skills data in `src/data/skills.ts` into the requested groups (`frontend`, `programming`, `tools`, `ai-collaboration`, `creative-direction`, `communication`) and adapted `src/types/skill.ts`. 
- Implemented privacy-aware contact data and safe `mailto:` construction (encoded subject/body) in `src/data/socialLinks.ts` and extended `src/types/contact.ts` with `id` and `accessibleLabel`. 
- Rewrote pages to use the new components: `src/pages/SkillsPage.tsx`, `src/pages/LinksPage.tsx`, and `src/pages/ContactPage.tsx`, and ensured public resources (GitHub project, Colab notebook, Python.org, AI tools, Notepad++, etc.) are presented while unconfirmed profiles remain private; reviewer should confirm the final public email. 

### Testing
- Ran linting with `npm run lint`, which completed successfully. 
- Attempted `npm run build` (runs `tsc --noEmit` then `vite build`), but type checking/build could not complete because `react-router-dom` was missing from resolved `node_modules` and `npm install` failed due to registry `403 Forbidden`, blocking dependency restoration. 
- Started dev server with `npm run dev`; Vite launched but reported unresolved imports for `react-router-dom` due to the missing dependency, so runtime verification is incomplete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2808789e60833090cbbc21a3a7bc28)