### PR TITLE
Add blog foundation for Algorithm of the Day and learning notes

### DIFF
--- a/src/components/portfolio/BlogCard.tsx
+++ b/src/components/portfolio/BlogCard.tsx
@@ -1,0 +1,52 @@
+import type { BlogPost } from '../../types/blog';
+
+type BlogCardProps = {
+  post: BlogPost;
+};
+
+const sourceLabels: Record<BlogPost['source'], string> = {
+  'typescript-data': 'TypeScript preview',
+  'markdown-placeholder': 'Markdown placeholder',
+  'future-mdx': 'Future MDX candidate',
+};
+
+function BlogCard({ post }: BlogCardProps) {
+  return (
+    <article className="info-panel blog-card">
+      <div className="blog-card-header">
+        <p className="status-label">{post.status}</p>
+        {post.placeholder ? <span className="featured-pill">Placeholder</span> : null}
+      </div>
+
+      <h3>{post.title}</h3>
+      <p>{post.summary}</p>
+
+      <dl className="blog-meta" aria-label={`${post.title} metadata`}>
+        <div>
+          <dt>Date</dt>
+          <dd>{post.dateLabel}</dd>
+        </div>
+        <div>
+          <dt>Format</dt>
+          <dd>{sourceLabels[post.source]}</dd>
+        </div>
+        <div>
+          <dt>Read</dt>
+          <dd>{post.readingTime}</dd>
+        </div>
+      </dl>
+
+      {post.contentPath ? (
+        <p className="blog-path">Future source: {post.contentPath}</p>
+      ) : null}
+
+      <div className="tag-list" aria-label={`${post.title} tags`}>
+        {post.tags.map((tag) => (
+          <span key={tag}>{tag}</span>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export default BlogCard;

--- a/src/components/portfolio/BlogCategoryTabs.tsx
+++ b/src/components/portfolio/BlogCategoryTabs.tsx
@@ -1,0 +1,46 @@
+import type { BlogCategory, BlogCategoryId } from '../../types/blog';
+
+export type BlogCategoryFilter = 'all' | BlogCategoryId;
+
+type BlogCategoryTabsProps = {
+  activeCategory: BlogCategoryFilter;
+  categories: readonly BlogCategory[];
+  postCounts: Readonly<Record<BlogCategoryId, number>>;
+  onCategoryChange: (category: BlogCategoryFilter) => void;
+};
+
+function BlogCategoryTabs({
+  activeCategory,
+  categories,
+  postCounts,
+  onCategoryChange,
+}: BlogCategoryTabsProps) {
+  const totalPostCount = categories.reduce(
+    (total, category) => total + postCounts[category.id],
+    0,
+  );
+
+  return (
+    <div className="blog-category-tabs" aria-label="Blog categories">
+      <button
+        type="button"
+        aria-pressed={activeCategory === 'all'}
+        onClick={() => onCategoryChange('all')}
+      >
+        All categories <span>{totalPostCount}</span>
+      </button>
+      {categories.map((category) => (
+        <button
+          key={category.id}
+          type="button"
+          aria-pressed={activeCategory === category.id}
+          onClick={() => onCategoryChange(category.id)}
+        >
+          {category.label} <span>{postCounts[category.id]}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default BlogCategoryTabs;

--- a/src/content/posts/algorithm-of-the-day-introduction.md
+++ b/src/content/posts/algorithm-of-the-day-introduction.md
@@ -1,0 +1,14 @@
+---
+title: Algorithm of the Day: Introduction
+category: algorithm-of-the-day
+status: planned
+source: markdown-placeholder
+---
+
+# Algorithm of the Day: Introduction
+
+> Placeholder draft: this Markdown file documents the intended future content shape. It is not yet wired into the React route.
+
+Algorithm of the Day will become a repeatable learning episode format: start with a signal from the world, translate it through a metaphor, invite a small reflective action, connect music or sound, and end with a question for the community.
+
+Future Markdown/MDX support should parse frontmatter, generate previews for `/blog`, and allow full post pages when the writing archive is ready.

--- a/src/data/blogPosts.ts
+++ b/src/data/blogPosts.ts
@@ -1,0 +1,92 @@
+import type { BlogCategory, BlogPost } from '../types/blog';
+
+export const blogCategories: readonly BlogCategory[] = [
+  {
+    id: 'algorithm-of-the-day',
+    label: 'Algorithm of the Day',
+    description:
+      'Episode scripts, rituals, and production notes for the Algorithm of the Day learning format.',
+  },
+  {
+    id: 'technical-notes',
+    label: 'Technical Notes',
+    description:
+      'Short implementation notes about React, TypeScript, portfolio architecture, and AI-assisted workflows.',
+  },
+  {
+    id: 'case-studies',
+    label: 'Case Studies',
+    description:
+      'Longer retrospectives that connect portfolio projects with goals, decisions, tradeoffs, and next steps.',
+  },
+  {
+    id: 'learning-log',
+    label: 'Learning Log',
+    description:
+      'Transparent learning entries that record practice, experiments, questions, and future improvements.',
+  },
+];
+
+export const blogPosts: readonly BlogPost[] = [
+  {
+    id: 'algorithm-of-the-day-introduction',
+    title: 'Algorithm of the Day: Introduction',
+    summary:
+      'Placeholder introduction for the daily learning ritual: a fact, a metaphor, a small action, and a community question.',
+    category: 'algorithm-of-the-day',
+    status: 'planned',
+    source: 'markdown-placeholder',
+    dateLabel: 'Planned foundation post',
+    readingTime: '3 min concept',
+    tags: ['Algorithm of the Day', 'Education', 'Ritual', 'Placeholder'],
+    placeholder: true,
+    contentPath: 'src/content/posts/algorithm-of-the-day-introduction.md',
+    relatedProjectId: 'algorithm-of-the-day',
+  },
+  {
+    id: 'portfolio-react-routing-notes',
+    title: 'React Portfolio Routing Notes',
+    summary:
+      'Placeholder technical note for documenting routing decisions, typed data modules, and reusable portfolio components.',
+    category: 'technical-notes',
+    status: 'planned',
+    source: 'typescript-data',
+    dateLabel: 'Planned technical note',
+    readingTime: '4 min outline',
+    tags: ['React', 'TypeScript', 'Routing', 'Placeholder'],
+    placeholder: true,
+  },
+  {
+    id: 'algorithm-of-the-day-case-study-draft',
+    title: 'Case Study Draft: Building a Learning Ritual',
+    summary:
+      'Placeholder case study connecting the Algorithm of the Day concept, audience, publishing workflow, and next milestones.',
+    category: 'case-studies',
+    status: 'draft',
+    source: 'future-mdx',
+    dateLabel: 'Draft case study',
+    readingTime: '6 min outline',
+    tags: ['Case Study', 'AI Collaboration', 'Publishing', 'Placeholder'],
+    placeholder: true,
+    relatedProjectId: 'algorithm-of-the-day',
+  },
+  {
+    id: 'learning-log-blog-foundation',
+    title: 'Learning Log: Blog Foundation',
+    summary:
+      'Placeholder log for tracking how this blog area evolves from typed previews into Markdown or MDX-powered writing.',
+    category: 'learning-log',
+    status: 'planned',
+    source: 'typescript-data',
+    dateLabel: 'Planned learning log',
+    readingTime: '2 min outline',
+    tags: ['Learning Log', 'Content Strategy', 'Markdown', 'Placeholder'],
+    placeholder: true,
+  },
+];
+
+export const markdownSupportNotes = [
+  'Current previews are plain TypeScript data so the route can launch without a content pipeline.',
+  'Markdown files can be introduced with frontmatter and imported through Vite glob imports in a later phase.',
+  'MDX is a future option when posts need interactive React examples, diagrams, or reusable portfolio components.',
+] as const;

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -11,7 +11,7 @@ export const navigationItems: readonly NavigationItem[] = [
   { to: routes.about, label: 'About' },
   { to: routes.projects, label: 'Projects' },
   { to: routes.skills, label: 'Skills' },
-  { to: routes.blog, label: 'Blog' },
+  { to: routes.blog, label: 'Blog / Insights' },
   { to: routes.contact, label: 'Contact' },
   { to: routes.links, label: 'Links' },
 ];

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,15 +1,92 @@
+import { useMemo, useState } from 'react';
+import BlogCard from '../components/portfolio/BlogCard';
+import BlogCategoryTabs, {
+  type BlogCategoryFilter,
+} from '../components/portfolio/BlogCategoryTabs';
+import { blogCategories, blogPosts, markdownSupportNotes } from '../data/blogPosts';
+import type { BlogCategoryId } from '../types/blog';
+
 function BlogPage() {
+  const [activeCategory, setActiveCategory] = useState<BlogCategoryFilter>('all');
+
+  const postCounts = useMemo(
+    () =>
+      blogCategories.reduce(
+        (counts, category) => ({
+          ...counts,
+          [category.id]: blogPosts.filter((post) => post.category === category.id)
+            .length,
+        }),
+        {} as Record<BlogCategoryId, number>,
+      ),
+    [],
+  );
+
+  const visibleCategories = blogCategories.filter(
+    (category) => activeCategory === 'all' || activeCategory === category.id,
+  );
+
   return (
-    <section className="page-card" aria-labelledby="page-title">
-      <p className="eyebrow">Blog</p>
-      <h1 id="page-title">Notes and Articles</h1>
+    <section className="page-card blog-page" aria-labelledby="page-title">
+      <p className="eyebrow">Blog / Insights</p>
+      <h1 id="page-title">Algorithm Episodes, Notes, and Learning Logs</h1>
       <p className="intro">
-        A routed writing shell for development notes, algorithms, tutorials, and project
-        retrospectives.
+        A foundation for Algorithm of the Day episodes, technical notes, project case
+        studies, and transparent learning logs.
       </p>
       <p className="page-note">
-        Blog entries can later be backed by markdown, a CMS, or typed local content.
+        Initial entries are clearly labeled placeholders. The route currently renders
+        typed TypeScript previews while the Markdown/MDX publishing model is decided in
+        a later phase.
       </p>
+
+      <BlogCategoryTabs
+        activeCategory={activeCategory}
+        categories={blogCategories}
+        postCounts={postCounts}
+        onCategoryChange={setActiveCategory}
+      />
+
+      <div className="blog-category-stack">
+        {visibleCategories.map((category) => {
+          const posts = blogPosts.filter((post) => post.category === category.id);
+
+          return (
+            <section
+              key={category.id}
+              className="blog-category-section"
+              aria-labelledby={category.id}
+            >
+              <div className="section-heading">
+                <p className="eyebrow">{category.label}</p>
+                <h2 id={category.id}>{category.label}</h2>
+                <p>{category.description}</p>
+              </div>
+
+              <div
+                className="card-grid blog-grid"
+                aria-label={`${category.label} post previews`}
+              >
+                {posts.map((post) => (
+                  <BlogCard key={post.id} post={post} />
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+
+      <aside
+        className="info-panel markdown-roadmap"
+        aria-labelledby="markdown-roadmap-title"
+      >
+        <h2 id="markdown-roadmap-title">Future Markdown/MDX support</h2>
+        <ul>
+          {markdownSupportNotes.map((note) => (
+            <li key={note}>{note}</li>
+          ))}
+        </ul>
+      </aside>
     </section>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -900,3 +900,145 @@ h1 {
     grid-template-columns: 1fr;
   }
 }
+
+.blog-page {
+  max-width: 1080px;
+  width: min(100%, 1080px);
+}
+
+.blog-category-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  justify-content: center;
+  margin: 1.5rem auto 0;
+}
+
+.blog-category-tabs button {
+  align-items: center;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(226, 232, 240, 0.24);
+  border-radius: 999px;
+  color: #dbeafe;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 800;
+  gap: 0.45rem;
+  padding: 0.55rem 0.9rem;
+}
+
+.blog-category-tabs button:hover,
+.blog-category-tabs button:focus-visible,
+.blog-category-tabs button[aria-pressed='true'] {
+  background: rgba(96, 165, 250, 0.22);
+  border-color: rgba(191, 219, 254, 0.44);
+}
+
+.blog-category-tabs span {
+  background: rgba(191, 219, 254, 0.16);
+  border-radius: 999px;
+  color: #ffffff;
+  min-width: 1.5rem;
+  padding: 0.1rem 0.45rem;
+  text-align: center;
+}
+
+.blog-category-stack {
+  display: grid;
+  gap: 2rem;
+  margin-top: 2rem;
+  text-align: left;
+}
+
+.blog-category-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.blog-category-section .section-heading {
+  margin-bottom: 0;
+}
+
+.blog-grid {
+  margin-top: 0;
+}
+
+.blog-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.blog-card-header {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.blog-card h3 {
+  color: #ffffff;
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.blog-meta {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+}
+
+.blog-meta div {
+  background: rgba(2, 6, 23, 0.28);
+  border: 1px solid rgba(226, 232, 240, 0.14);
+  border-radius: 0.85rem;
+  padding: 0.7rem;
+}
+
+.blog-meta dt,
+.blog-meta dd {
+  margin: 0;
+}
+
+.blog-meta dt {
+  color: #ffffff;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.2rem;
+  text-transform: uppercase;
+}
+
+.blog-meta dd,
+.blog-path {
+  color: #dbeafe;
+  font-size: 0.9rem;
+}
+
+.blog-path {
+  background: rgba(96, 165, 250, 0.12);
+  border: 1px solid rgba(147, 197, 253, 0.22);
+  border-radius: 0.85rem;
+  margin: 0;
+  padding: 0.7rem;
+}
+
+.markdown-roadmap {
+  margin-top: 2rem;
+  text-align: left;
+}
+
+.markdown-roadmap h2 {
+  color: #ffffff;
+  margin-top: 0;
+}
+
+@media (max-width: 560px) {
+  .blog-meta {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,11 +1,34 @@
 export type BlogPostStatus = 'draft' | 'planned' | 'published';
 
+export type BlogCategoryId =
+  | 'algorithm-of-the-day'
+  | 'technical-notes'
+  | 'case-studies'
+  | 'learning-log';
+
+export type BlogCategory = {
+  id: BlogCategoryId;
+  label: string;
+  description: string;
+};
+
+export type BlogContentSource =
+  | 'typescript-data'
+  | 'markdown-placeholder'
+  | 'future-mdx';
+
 export type BlogPost = {
   id: string;
   title: string;
   summary: string;
+  category: BlogCategoryId;
   status: BlogPostStatus;
+  source: BlogContentSource;
+  dateLabel: string;
+  readingTime: string;
   tags: readonly string[];
+  placeholder?: boolean;
+  contentPath?: string;
   relatedProjectId?: string;
 };
 


### PR DESCRIPTION
### Motivation
- Provide a typed, component-backed blog/insights area to host "Algorithm of the Day" episodes, technical notes, case studies, and learning logs as a foundation for future Markdown/MDX publishing.
- Surface clearly labeled placeholder posts so the `/blog` route can launch before a content pipeline is introduced.

### Description
- Add typed blog models and metadata with `BlogCategory`/`BlogPost` types and explicit `source`/`placeholder` fields in `src/types/blog.ts`.
- Seed categories, placeholder posts, and Markdown/MDX roadmap in `src/data/blogPosts.ts` and add an initial Markdown placeholder `src/content/posts/algorithm-of-the-day-introduction.md`.
- Implement reusable UI components `src/components/portfolio/BlogCard.tsx` and `src/components/portfolio/BlogCategoryTabs.tsx` and wire them into an expanded `/blog` page at `src/pages/BlogPage.tsx` to show previews grouped by category with filtering.
- Update navigation label to `Blog / Insights` in `src/data/navigation.ts` and add responsive blog styles in `src/styles/globals.css`.

### Testing
- Ran `npm run lint`, which completed successfully for the committed changes.
- Ran `npx prettier --check` against the new/modified files, which succeeded after formatting the touched files with Prettier.
- `npm run typecheck` failed because local type resolution for existing router imports could not find `react-router-dom` types (missing in `node_modules`).
- `npm install` failed due to a `403 Forbidden` from the npm registry for `react-router-dom`, which also blocked `npm run build` (typecheck step) from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a280c4c0bbc8330bd00fa457335f7c8)