### PR TITLE
Pin Vite toolchain for Windows development

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ Start the local development server:
 npm run dev
 ```
 
+### Windows native binding troubleshooting
+
+This project pins Vite to the latest Vite 7 line instead of using `latest`. Vite 8 switched core development/build internals to Rolldown/Oxc native packages, and the Windows native Rolldown binding can fail to load with errors such as `Cannot find native binding` or `ERR_DLOPEN_FAILED` on some machines.
+
+If you previously installed dependencies while `vite` was set to `latest`, clear the generated install artifacts and reinstall so npm resolves the pinned versions from `package.json`:
+
+```powershell
+Remove-Item -Recurse -Force node_modules, package-lock.json -ErrorAction SilentlyContinue
+npm install
+npm run dev
+```
+
+Use Node.js 20.19+ or newer. The hosted build configurations use Node 22 where a host-specific Node version is required.
+
 Build the static site:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -16,21 +16,25 @@
     "ci:quality": "npm run lint && npm run typecheck && npm run test && npm run build"
   },
   "dependencies": {
-    "react": "latest",
-    "react-dom": "latest",
-    "react-router-dom": "latest"
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "react-router-dom": "7.17.0"
   },
   "devDependencies": {
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
-    "@vitejs/plugin-react": "latest",
-    "typescript": "latest",
-    "vite": "latest",
-    "@eslint/js": "latest",
-    "eslint": "latest",
-    "eslint-plugin-react-hooks": "latest",
-    "eslint-plugin-react-refresh": "latest",
-    "prettier": "latest",
-    "typescript-eslint": "latest"
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "5.1.4",
+    "typescript": "6.0.3",
+    "vite": "7.3.5",
+    "@eslint/js": "10.0.1",
+    "eslint": "10.4.1",
+    "eslint-plugin-react-hooks": "7.1.1",
+    "eslint-plugin-react-refresh": "0.5.2",
+    "prettier": "3.8.4",
+    "typescript-eslint": "8.61.0"
+  },
+  "packageManager": "npm@11.11.0",
+  "engines": {
+    "node": ">=20.19.0"
   }
 }


### PR DESCRIPTION
### Motivation

- Prevent Windows developers from hitting Vite 8 / Rolldown native binding failures by avoiding floating `latest` ranges that can pull in Vite 8 with native bindings that fail to load on some machines.

### Description

- Replace broad `latest` dependency ranges in `package.json` with exact versions, including `vite@7.3.5` and `@vitejs/plugin-react@5.1.4`, and pinned React/TypeScript toolchain versions.
- Add `packageManager: "npm@11.11.0"` and `engines.node: ">=20.19.0"` to clarify the supported install/runtime baseline.
- Add a Windows troubleshooting section to `README.md` documenting the cleanup and reinstall steps (`Remove-Item -Recurse -Force node_modules, package-lock.json` and `npm install`) and guidance about Node.js version expectations.

### Testing

- Ran `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json OK')"` which succeeded and validated the edited `package.json`.
- Attempted `npm install --package-lock-only` which failed due to the environment returning HTTP 403 from the npm registry, so lockfile generation could not be completed.
- Attempted `npm install --package-lock-only --offline` which failed with `ENOTCACHED` because required tarballs were not available in the local cache.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a284e9837808330bf8f1fd790a5be95)